### PR TITLE
Make .indexes compatible with older SQLite versions

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -145,9 +145,9 @@ class Table:
                 columns.append(name)
             row["columns"] = columns
             # These coluns may be missing on older SQLite versions:
-            for key in ("origin", "partial"):
+            for key, default in {"origin": "c", "partial": 0}.items():
                 if key not in row:
-                    row[key] = None
+                    row[key] = default
             indexes.append(Index(**row))
         return indexes
 

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -144,6 +144,10 @@ class Table:
             for seqno, cid, name in self.db.conn.execute(column_sql).fetchall():
                 columns.append(name)
             row["columns"] = columns
+            # These coluns may be missing on older SQLite versions:
+            for key in ("origin", "partial"):
+                if key not in row:
+                    row[key] = None
             indexes.append(Index(**row))
         return indexes
 


### PR DESCRIPTION
Older SQLite versions return a different set of columns from the PRAGMA we are using.