### PR TITLE
Work in progress: m2m() method for creating many-to-many records

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -297,6 +297,17 @@ class Database:
             )
         )
 
+    def m2m_table_candidates(self, table, other_table):
+        "Returns potential m2m tables for arguments, based on FKs"
+        candidates = []
+        tables = {table, other_table}
+        for table in self.tables:
+            # Does it have foreign keys to both table and other_table?
+            has_fks_to = {fk.other_table for fk in table.foreign_keys}
+            if has_fks_to.issuperset(tables):
+                candidates.append(table.name)
+        return candidates
+
     def add_foreign_keys(self, foreign_keys):
         # foreign_keys is a list of explicit 4-tuples
         assert all(

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1048,21 +1048,31 @@ class Table:
             self.create_index(column_values.keys(), unique=True)
             return pk
 
-    def m2m(self, other_table, record_or_list, pk=None):
+    def m2m(self, other_table, record_or_list=None, pk=None, lookup=None):
         our_id = self.last_pk
-        records = (
-            [record_or_list]
-            if not isinstance(record_or_list, (list, tuple))
-            else record_or_list
-        )
+        if lookup is not None:
+            assert record_or_list is None, "Provide lookup= or record, not both"
+        else:
+            assert record_or_list is not None, "Provide lookup= or record, not both"
         tables = list(sorted([self.name, other_table]))
         columns = ["{}_id".format(t) for t in tables]
         m2m_table = self.db.table(
             "{}_{}".format(*tables), pk=columns, foreign_keys=columns
         )
-        # Ensure each record exists in other table
-        for record in records:
-            id = self.db[other_table].upsert(record, pk=pk).last_pk
+        if lookup is None:
+            records = (
+                [record_or_list]
+                if not isinstance(record_or_list, (list, tuple))
+                else record_or_list
+            )
+            # Ensure each record exists in other table
+            for record in records:
+                id = self.db[other_table].upsert(record, pk=pk).last_pk
+                m2m_table.upsert(
+                    {"{}_id".format(other_table): id, "{}_id".format(self.name): our_id}
+                )
+        else:
+            id = self.db[other_table].lookup(lookup)
             m2m_table.upsert(
                 {"{}_id".format(other_table): id, "{}_id".format(self.name): our_id}
             )

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1048,7 +1048,9 @@ class Table:
             self.create_index(column_values.keys(), unique=True)
             return pk
 
-    def m2m(self, other_table, record_or_list=None, pk=None, lookup=None):
+    def m2m(
+        self, other_table, record_or_list=None, pk=None, lookup=None, m2m_table=None
+    ):
         our_id = self.last_pk
         if lookup is not None:
             assert record_or_list is None, "Provide lookup= or record, not both"
@@ -1056,9 +1058,8 @@ class Table:
             assert record_or_list is not None, "Provide lookup= or record, not both"
         tables = list(sorted([self.name, other_table]))
         columns = ["{}_id".format(t) for t in tables]
-        m2m_table = self.db.table(
-            "{}_{}".format(*tables), pk=columns, foreign_keys=columns
-        )
+        m2m_table_name = m2m_table or "{}_{}".format(*tables)
+        m2m_table = self.db.table(m2m_table_name, pk=columns, foreign_keys=columns)
         if lookup is None:
             records = (
                 [record_or_list]

--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -41,3 +41,20 @@ def test_insert_m2m_list(fresh_db):
             other_column="id",
         ),
     ] == dogs_humans.foreign_keys
+
+
+def test_m2m_explicit_argument(fresh_db):
+    # .m2m("humans", ..., m2m_table="relationships")
+    assert False
+
+
+def test_uses_existing_m2m_table_if_exists(fresh_db):
+    # Code should look for an existing toble with fks to both tables
+    # and use that if it exists.
+    assert False
+
+
+def test_requires_explicit_m2m_table_if_multiple_options(fresh_db):
+    # If the code scans for m2m tables and finds more than one candidate
+    # it should require that the m2m_table=x argument is used
+    assert False

--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -43,6 +43,19 @@ def test_insert_m2m_list(fresh_db):
     ] == dogs_humans.foreign_keys
 
 
+def test_m2m_with_table_objects(fresh_db):
+    dogs = fresh_db.table("dogs", pk="id")
+    humans = fresh_db.table("humans", pk="id")
+    dogs.insert({"id": 1, "name": "Cleo"}).m2m(
+        humans, [{"id": 1, "name": "Natalie D"}, {"id": 2, "name": "Simon W"}]
+    )
+    expected_tables = {"dogs", "humans", "dogs_humans"}
+    assert expected_tables == set(fresh_db.table_names())
+    assert 1 == dogs.count
+    assert 2 == humans.count
+    assert 2 == fresh_db["dogs_humans"].count
+
+
 def test_m2m_lookup(fresh_db):
     people = fresh_db.table("people", pk="id")
     people.insert({"name": "Wahyu"}).m2m("tags", lookup={"tag": "Coworker"})

--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -1,0 +1,43 @@
+from sqlite_utils.db import ForeignKey
+import pytest
+
+
+def test_insert_m2m_single(fresh_db):
+    dogs = fresh_db["dogs"]
+    dogs.insert({"id": 1, "name": "Cleo"}, pk="id").m2m(
+        "humans", {"id": 1, "name": "Natalie D"}, pk="id"
+    )
+    assert {"dogs_humans", "humans", "dogs"} == set(fresh_db.table_names())
+    humans = fresh_db["humans"]
+    dogs_humans = fresh_db["dogs_humans"]
+    assert [{"id": 1, "name": "Natalie D"}] == list(humans.rows)
+    assert [{"humans_id": 1, "dogs_id": 1}] == list(dogs_humans.rows)
+
+
+def test_insert_m2m_list(fresh_db):
+    dogs = fresh_db["dogs"]
+    dogs.insert({"id": 1, "name": "Cleo"}, pk="id").m2m(
+        "humans",
+        [{"id": 1, "name": "Natalie D"}, {"id": 2, "name": "Simon W"}],
+        pk="id",
+    )
+    assert {"dogs", "humans", "dogs_humans"} == set(fresh_db.table_names())
+    humans = fresh_db["humans"]
+    dogs_humans = fresh_db["dogs_humans"]
+    assert [{"humans_id": 1, "dogs_id": 1}, {"humans_id": 2, "dogs_id": 1}] == list(
+        dogs_humans.rows
+    )
+    assert [{"id": 1, "name": "Natalie D"}, {"id": 2, "name": "Simon W"}] == list(
+        humans.rows
+    )
+    assert [
+        ForeignKey(
+            table="dogs_humans", column="dogs_id", other_table="dogs", other_column="id"
+        ),
+        ForeignKey(
+            table="dogs_humans",
+            column="humans_id",
+            other_table="humans",
+            other_column="id",
+        ),
+    ] == dogs_humans.foreign_keys

--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -84,6 +84,28 @@ def test_m2m_explicit_table_name_argument(fresh_db):
     assert not fresh_db["people_tags"].exists
 
 
+def test_m2m_table_candidates(fresh_db):
+    fresh_db.create_table("one", {"id": int, "name": str}, pk="id")
+    fresh_db.create_table("two", {"id": int, "name": str}, pk="id")
+    fresh_db.create_table("three", {"id": int, "name": str}, pk="id")
+    # No candidates at first
+    assert [] == fresh_db.m2m_table_candidates("one", "two")
+    # Create a candidate
+    fresh_db.create_table(
+        "one_m2m_two", {"one_id": int, "two_id": int}, foreign_keys=["one_id", "two_id"]
+    )
+    assert ["one_m2m_two"] == fresh_db.m2m_table_candidates("one", "two")
+    # Add another table and there should be two candidates
+    fresh_db.create_table(
+        "one_m2m_two_and_three",
+        {"one_id": int, "two_id": int, "three_id": int},
+        foreign_keys=["one_id", "two_id", "three_id"],
+    )
+    assert {"one_m2m_two", "one_m2m_two_and_three"} == set(
+        fresh_db.m2m_table_candidates("one", "two")
+    )
+
+
 def test_uses_existing_m2m_table_if_exists(fresh_db):
     # Code should look for an existing toble with fks to both tables
     # and use that if it exists.

--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -74,9 +74,14 @@ def test_m2m_requires_either_records_or_lookup(fresh_db):
         people.m2m("tags", {"tag": "hello"}, lookup={"foo": "bar"})
 
 
-def test_m2m_explicit_argument(fresh_db):
-    # .m2m("humans", ..., m2m_table="relationships")
-    assert False
+def test_m2m_explicit_table_name_argument(fresh_db):
+    people = fresh_db.table("people", pk="id")
+    people.insert({"name": "Wahyu"}).m2m(
+        "tags", lookup={"tag": "Coworker"}, m2m_table="tagged"
+    )
+    assert fresh_db["tags"].exists
+    assert fresh_db["tagged"].exists
+    assert not fresh_db["people_tags"].exists
 
 
 def test_uses_existing_m2m_table_if_exists(fresh_db):


### PR DESCRIPTION
- [x] `table.insert({"name": "Barry"}).m2m("tags", lookup={"tag": "Coworker"})`
- [x] Explicit table name `.m2m("humans", ..., m2m_table="relationships")`
- [x] Automatically use an existing m2m table if a single obvious candidate exists (a table with two foreign keys in the correct directions)
- [x] Require the explicit `m2m_table=` argument if multiple candidates for the m2m table exist
- [x] Documentation

Refs #23