### PR TITLE
Escape the table name in populate_fts and search.

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -729,7 +729,7 @@ class Table(Queryable):
     def populate_fts(self, columns):
         sql = """
             INSERT INTO "{table}_fts" (rowid, {columns})
-                SELECT rowid, {columns} FROM {table};
+                SELECT rowid, {columns} FROM "{table}";
         """.format(
             table=self.name, columns=", ".join(columns)
         )
@@ -796,7 +796,7 @@ class Table(Queryable):
 
     def search(self, q):
         sql = """
-            select * from {table} where rowid in (
+            select * from "{table}" where rowid in (
                 select rowid from [{table}_fts]
                 where [{table}_fts] match :search
             )


### PR DESCRIPTION
The table names weren't escaped using double quotes in the populate_fts method. 

Reproducible case: 
```
>>> import sqlite_utils
>>> db = sqlite_utils.Database("abc.db")
>>> db["http://example.com"].insert_all([
...     {"id": 1, "age": 4, "name": "Cleo"},
...     {"id": 2, "age": 2, "name": "Pancakes"}
... ], pk="id")
<Table http://example.com (id, age, name)>
>>> db["http://example.com"].enable_fts(["name"])
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    db["http://example.com"].enable_fts(["name"])
  File "/home/amjith/.virtualenvs/itsysearch/lib/python3.7/site-packages/sqlite_utils/db.py", l
ine 705, in enable_fts
    self.populate_fts(columns)
  File "/home/amjith/.virtualenvs/itsysearch/lib/python3.7/site-packages/sqlite_utils/db.py", l
ine 715, in populate_fts
    self.db.conn.executescript(sql)
sqlite3.OperationalError: unrecognized token: ":"
>>> 
```