### PR TITLE
Add triggers while enabling FTS

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -266,12 +266,12 @@ def create_index(path, table, column, name, unique, if_not_exists):
 @click.option("--fts4", help="Use FTS4", default=False, is_flag=True)
 @click.option("--fts5", help="Use FTS5", default=False, is_flag=True)
 @click.option(
-    "--create-update-triggers",
+    "--create-triggers",
     help="Create triggers to update the FTS tables when the parent table changes.",
     default=False,
     is_flag=True,
 )
-def enable_fts(path, table, column, fts4, fts5, create_update_triggers):
+def enable_fts(path, table, column, fts4, fts5, create_triggers):
     "Enable FTS for specific table and columns"
     fts_version = "FTS5"
     if fts4 and fts5:
@@ -282,7 +282,7 @@ def enable_fts(path, table, column, fts4, fts5, create_update_triggers):
 
     db = sqlite_utils.Database(path)
     db[table].enable_fts(
-        column, fts_version=fts_version, create_update_triggers=create_update_triggers
+        column, fts_version=fts_version, create_triggers=create_triggers
     )
 
 

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -265,7 +265,13 @@ def create_index(path, table, column, name, unique, if_not_exists):
 @click.argument("column", nargs=-1, required=True)
 @click.option("--fts4", help="Use FTS4", default=False, is_flag=True)
 @click.option("--fts5", help="Use FTS5", default=False, is_flag=True)
-def enable_fts(path, table, column, fts4, fts5):
+@click.option(
+    "--create-update-triggers",
+    help="Create triggers to update the FTS tables when the parent table changes.",
+    default=False,
+    is_flag=True,
+)
+def enable_fts(path, table, column, fts4, fts5, create_update_triggers):
     "Enable FTS for specific table and columns"
     fts_version = "FTS5"
     if fts4 and fts5:
@@ -275,7 +281,9 @@ def enable_fts(path, table, column, fts4, fts5):
         fts_version = "FTS4"
 
     db = sqlite_utils.Database(path)
-    db[table].enable_fts(column, fts_version=fts_version)
+    db[table].enable_fts(
+        column, fts_version=fts_version, create_update_triggers=create_update_triggers
+    )
 
 
 @cli.command(name="populate-fts")

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -729,7 +729,7 @@ class Table(Queryable):
     def populate_fts(self, columns):
         sql = """
             INSERT INTO "{table}_fts" (rowid, {columns})
-                SELECT rowid, {columns} FROM {table};
+                SELECT rowid, {columns} FROM "{table}";
         """.format(
             table=self.name, columns=", ".join(columns)
         )
@@ -796,7 +796,7 @@ class Table(Queryable):
 
     def search(self, q):
         sql = """
-            select * from {table} where rowid in (
+            select * from "{table}" where rowid in (
                 select rowid from [{table}_fts]
                 where [{table}_fts] match :search
             )

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -713,9 +713,9 @@ class Table(Queryable):
     def enable_fts(self, columns, fts_version="FTS5", create_triggers=False):
         "Enables FTS on the specified columns."
         sql = """
-            CREATE VIRTUAL TABLE "{table}_fts" USING {fts_version} (
+            CREATE VIRTUAL TABLE [{table}_fts] USING {fts_version} (
                 {columns},
-                content="{table}"
+                content=[{table}]
             );
         """.format(
             table=self.name,
@@ -729,15 +729,15 @@ class Table(Queryable):
             old_cols = ", ".join("old.[{}]".format(c) for c in columns)
             new_cols = ", ".join("new.[{}]".format(c) for c in columns)
             triggers = """
-                CREATE TRIGGER "{table}_ai" AFTER INSERT ON "{table}" BEGIN
-                  INSERT INTO "{table}_fts" (rowid, {columns}) VALUES (new.rowid, {new_cols});
+                CREATE TRIGGER [{table}_ai] AFTER INSERT ON [{table}] BEGIN
+                  INSERT INTO [{table}_fts] (rowid, {columns}) VALUES (new.rowid, {new_cols});
                 END;
-                CREATE TRIGGER "{table}_ad" AFTER DELETE ON "{table}" BEGIN
-                  INSERT INTO "{table}_fts" ("{table}_fts", rowid, {columns}) VALUES('delete', old.rowid, {old_cols});
+                CREATE TRIGGER [{table}_ad] AFTER DELETE ON [{table}] BEGIN
+                  INSERT INTO [{table}_fts] ([{table}_fts], rowid, {columns}) VALUES('delete', old.rowid, {old_cols});
                 END;
-                CREATE TRIGGER "{table}_au" AFTER UPDATE ON "{table}" BEGIN
-                  INSERT INTO "{table}_fts" ("{table}_fts", rowid, {columns}) VALUES('delete', old.rowid, {old_cols});
-                  INSERT INTO "{table}_fts" (rowid, {columns}) VALUES (new.rowid, {new_cols});
+                CREATE TRIGGER [{table}_au] AFTER UPDATE ON [{table}] BEGIN
+                  INSERT INTO [{table}_fts] ([{table}_fts], rowid, {columns}) VALUES('delete', old.rowid, {old_cols});
+                  INSERT INTO [{table}_fts] (rowid, {columns}) VALUES (new.rowid, {new_cols});
                 END;
             """.format(
                 table=self.name,
@@ -750,8 +750,8 @@ class Table(Queryable):
 
     def populate_fts(self, columns):
         sql = """
-            INSERT INTO "{table}_fts" (rowid, {columns})
-                SELECT rowid, {columns} FROM "{table}";
+            INSERT INTO [{table}_fts] (rowid, {columns})
+                SELECT rowid, {columns} FROM [{table}];
         """.format(
             table=self.name, columns=", ".join(columns)
         )

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -710,7 +710,7 @@ class Table(Queryable):
             )
         self.db.add_foreign_keys([(self.name, column, other_table, other_column)])
 
-    def enable_fts(self, columns, fts_version="FTS5", create_update_triggers=False):
+    def enable_fts(self, columns, fts_version="FTS5", create_triggers=False):
         "Enables FTS on the specified columns."
         sql = """
             CREATE VIRTUAL TABLE "{table}_fts" USING {fts_version} (
@@ -725,7 +725,7 @@ class Table(Queryable):
         self.db.conn.executescript(sql)
         self.populate_fts(columns)
 
-        if create_update_triggers:
+        if create_triggers:
             old_cols = ", ".join("old.[{}]".format(c) for c in columns)
             new_cols = ", ".join("new.[{}]".format(c) for c in columns)
             triggers = """

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -646,7 +646,7 @@ class Table(Queryable):
         return self
 
     def drop(self):
-        self.db.conn.execute("DROP TABLE {}".format(self.name))
+        self.db.conn.execute("DROP TABLE [{}]".format(self.name))
 
     def guess_foreign_table(self, column):
         column = column.lower()
@@ -760,21 +760,20 @@ class Table(Queryable):
 
     def detect_fts(self):
         "Detect if table has a corresponding FTS virtual table and return it"
-        rows = self.db.conn.execute(
-            """
+        sql = """
             SELECT name FROM sqlite_master
                 WHERE rootpage = 0
                 AND (
-                    sql LIKE '%VIRTUAL TABLE%USING FTS%content="{table}"%'
+                    sql LIKE '%VIRTUAL TABLE%USING FTS%content=%{table}%'
                     OR (
                         tbl_name = "{table}"
                         AND sql LIKE '%VIRTUAL TABLE%USING FTS%'
                     )
                 )
         """.format(
-                table=self.name
-            )
-        ).fetchall()
+            table=self.name
+        )
+        rows = self.db.conn.execute(sql).fetchall()
         if len(rows) == 0:
             return None
         else:
@@ -1166,7 +1165,7 @@ class View(Queryable):
         )
 
     def drop(self):
-        self.db.conn.execute("DROP VIEW {}".format(self.name))
+        self.db.conn.execute("DROP VIEW [{}]".format(self.name))
 
 
 def chunks(sequence, size):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,7 +335,7 @@ def test_enable_fts_with_triggers(db_path):
         CliRunner()
         .invoke(
             cli.cli,
-            ["enable-fts", db_path, "Gosh", "c1", "--fts4", "--create-update-triggers"],
+            ["enable-fts", db_path, "Gosh", "c1", "--fts4", "--create-triggers"],
         )
         .exit_code
     )

--- a/tests/test_enable_fts.py
+++ b/tests/test_enable_fts.py
@@ -48,3 +48,16 @@ def test_optimize_fts(fresh_db):
         "searchable_5_fts",
     ):
         fresh_db[table_name].optimize()
+
+
+def test_enable_fts_w_triggers(fresh_db):
+    table = fresh_db["searchable"]
+    table.insert(search_records[0])
+    table.enable_fts(
+        ["text", "country"], fts_version="FTS4", create_update_triggers=True
+    )
+    assert [("tanuki are tricksters", "Japan", "foo")] == table.search("tanuki")
+    table.insert(search_records[1])
+    # Triggers will auto-populate FTS virtual table, not need to call populate_fts()
+    assert [("racoons are trash pandas", "USA", "bar")] == table.search("usa")
+    assert [] == table.search("bar")

--- a/tests/test_enable_fts.py
+++ b/tests/test_enable_fts.py
@@ -54,7 +54,7 @@ def test_enable_fts_w_triggers(fresh_db):
     table = fresh_db["searchable"]
     table.insert(search_records[0])
     table.enable_fts(
-        ["text", "country"], fts_version="FTS4", create_update_triggers=True
+        ["text", "country"], fts_version="FTS4", create_triggers=True
     )
     assert [("tanuki are tricksters", "Japan", "foo")] == table.search("tanuki")
     table.insert(search_records[1])


### PR DESCRIPTION
This adds the option for a user to set up triggers in the database to keep their FTS table in sync with the parent table. 

Ref: https://sqlite.org/fts5.html#external_content_and_contentless_tables

I would prefer to make the creation of triggers the default behavior, but that will break existing usage where people have been calling `populate_fts` after inserting new rows.

I am happy to make changes to the PR as you see fit. 