### PR TITLE
Explicitly include tests and docs in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.md
+recursive-include docs *.rst
+recursive-include tests *.py

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author="Simon Willison",
     version=VERSION,
     license="Apache License, Version 2.0",
-    packages=find_packages(exclude="tests"),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=["click", "click-default-group", "tabulate"],
     setup_requires=["pytest-runner"],
     extras_require={


### PR DESCRIPTION
Also exclude 'tests' from runtime installation.