### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Now you can do things with the CLI utility like this:
 You can even import data into a new database table like this:
 
     $ curl https://api.github.com/repos/simonw/sqlite-utils/releases \
-        | sqlite-utils insert releases.db releases - --pk
+        | sqlite-utils insert releases.db releases - --pk "id"
 
 Full CLI documentation: https://sqlite-utils.readthedocs.io/en/stable/cli.html
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Now you can do things with the CLI utility like this:
 You can even import data into a new database table like this:
 
     $ curl https://api.github.com/repos/simonw/sqlite-utils/releases \
-        | sqlite-utils insert releases.db releases - --pk "id"
+        | sqlite-utils insert releases.db releases - --pk id
 
 Full CLI documentation: https://sqlite-utils.readthedocs.io/en/stable/cli.html
 


### PR DESCRIPTION
The `sqlite-utils insert releases.db releases - --pk` is missing the pk field name, added ` "id"` to fix it.