### PR TITLE
Allow iterables other than Lists in m2m records

### DIFF
--- a/tests/test_m2m.py
+++ b/tests/test_m2m.py
@@ -31,16 +31,52 @@ def test_insert_m2m_list(fresh_db):
         humans.rows
     )
     assert [
-        ForeignKey(
-            table="dogs_humans", column="dogs_id", other_table="dogs", other_column="id"
-        ),
-        ForeignKey(
-            table="dogs_humans",
-            column="humans_id",
-            other_table="humans",
-            other_column="id",
-        ),
-    ] == dogs_humans.foreign_keys
+               ForeignKey(
+                   table="dogs_humans", column="dogs_id", other_table="dogs", other_column="id"
+               ),
+               ForeignKey(
+                   table="dogs_humans",
+                   column="humans_id",
+                   other_table="humans",
+                   other_column="id",
+               ),
+           ] == dogs_humans.foreign_keys
+
+
+def test_insert_m2m_iterable(fresh_db):
+    iterable_records = ({"id": 1, "name": "Phineas"}, {"id": 2, "name": "Ferb"})
+
+    def iterable():
+        for record in iterable_records:
+            yield record
+
+    platypuses = fresh_db["platypuses"]
+    platypuses.insert({"id": 1, "name": "Perry"}, pk="id").m2m(
+        "humans",
+        iterable(),
+        pk="id",
+    )
+
+    assert {"platypuses", "humans", "humans_platypuses"} == set(fresh_db.table_names())
+    humans = fresh_db["humans"]
+    humans_platypuses = fresh_db["humans_platypuses"]
+    assert [{"humans_id": 1, "platypuses_id": 1}, {"humans_id": 2, "platypuses_id": 1}] == list(
+        humans_platypuses.rows
+    )
+    assert [{"id": 1, "name": "Phineas"}, {"id": 2, "name": "Ferb"}] == list(
+        humans.rows
+    )
+    assert [
+               ForeignKey(
+                   table="humans_platypuses", column="platypuses_id", other_table="platypuses", other_column="id"
+               ),
+               ForeignKey(
+                   table="humans_platypuses",
+                   column="humans_id",
+                   other_table="humans",
+                   other_column="id",
+               ),
+           ] == humans_platypuses.foreign_keys
 
 
 def test_m2m_with_table_objects(fresh_db):
@@ -64,16 +100,16 @@ def test_m2m_lookup(fresh_db):
     assert people_tags.exists()
     assert tags.exists()
     assert [
-        ForeignKey(
-            table="people_tags",
-            column="people_id",
-            other_table="people",
-            other_column="id",
-        ),
-        ForeignKey(
-            table="people_tags", column="tags_id", other_table="tags", other_column="id"
-        ),
-    ] == people_tags.foreign_keys
+               ForeignKey(
+                   table="people_tags",
+                   column="people_id",
+                   other_table="people",
+                   other_column="id",
+               ),
+               ForeignKey(
+                   table="people_tags", column="tags_id", other_table="tags", other_column="id"
+               ),
+           ] == people_tags.foreign_keys
     assert [{"people_id": 1, "tags_id": 1}] == list(people_tags.rows)
     assert [{"id": 1, "name": "Wahyu"}] == list(people.rows)
     assert [{"id": 1, "tag": "Coworker"}] == list(tags.rows)


### PR DESCRIPTION
I was playing around with sqlite-utils, creating a Roam Research dogsheep-style importer for Datasette, and ran into a slight snag.

I wanted to use a generator to add an order column in an importer. It looked something like:

```
def order_generator(iterable, attr=None):
    if attr is None:
        attr = "order"
    order: int = 0

    for i in iterable:
        i[attr] = order
        order += 1
        yield i
```

When I used this with `insert_all` and other things, it worked fine--but it didn't work as the `records` argument to `m2m`.  I dug into it, and sqlite-utils is explicitly checking if the records argument is a list or a tuple.  I flipped the check upside down, and now it checks if the argument is a mapping.  If it's a mapping, it wraps it in a list, otherwise it leaves it alone.

(I get that it might not really make sense to put the order column on the second table.  I changed my import schema a bit, and no longer have a real example, but maybe this change still makes sense.)

The automated tests still pass, but I did not add any new ones.

Let me know what you think! I'm really loving Datasette and its ecosystem; thanks for everything!