### PR TITLE
fix for problem in Table.insert_all on search for columns per chunk of rows

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1886,12 +1886,12 @@ class Table(Queryable):
                 if hash_id:
                     all_columns.insert(0, hash_id)
             else:
-                all_columns += [
-                    column
-                    for record in chunk
-                    for column in record
-                    if column not in all_columns
-                ]
+                for record in chunk:
+                    all_columns += [
+                        column
+                        for column in record
+                        if column not in all_columns
+                    ]
 
             validate_column_names(all_columns)
             first = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from click.testing import CliRunner
 import json
 import os
 import pytest
+import sys
 from sqlite_utils.utils import sqlite3, find_spatialite
 import textwrap
 
@@ -93,7 +94,10 @@ def test_tables_counts_and_columns_csv(db_path, format, expected):
     result = CliRunner().invoke(
         cli.cli, ["tables", "--counts", "--columns", format, db_path]
     )
-    assert result.output.strip() == expected
+    if sys.platform == 'win32':
+        assert result.output.strip().replace('\r', '') == expected
+    else:
+        assert result.output.strip() == expected
 
 
 def test_tables_schema(db_path):
@@ -860,12 +864,18 @@ def test_query_csv(db_path, format, expected):
         cli.cli, [db_path, "select id, name, age from dogs", format]
     )
     assert 0 == result.exit_code
-    assert result.output == expected
+    if sys.platform == 'win32':
+        assert result.output.replace('\r', '') == expected
+    else:
+        assert result.output == expected
     # Test the no-headers option:
     result = CliRunner().invoke(
         cli.cli, [db_path, "select id, name, age from dogs", "--no-headers", format]
     )
-    assert result.output.strip() == "\n".join(expected.split("\n")[1:]).strip()
+    if sys.platform == 'win32':
+        assert result.output.strip().replace('\r', '') == "\n".join(expected.split("\n")[1:]).strip()
+    else:
+        assert result.output.strip() == "\n".join(expected.split("\n")[1:]).strip()
 
 
 _all_query = "select id, name, age from dogs"
@@ -1750,7 +1760,10 @@ def test_search(tmpdir, fts, extra_arg, expected):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert result.output == expected
+    if sys.platform == 'win32':
+        assert result.output.replace('\r', '') == expected
+    else:
+        assert result.output == expected
 
 
 _TRIGGERS_EXPECTED = '[{"name": "blah", "table": "articles", "sql": "CREATE TRIGGER blah AFTER INSERT ON articles\\nBEGIN\\n    UPDATE counter SET count = count + 1;\\nEND"}]\n'

--- a/tests/test_insert_files.py
+++ b/tests/test_insert_files.py
@@ -1,3 +1,5 @@
+import os
+
 from sqlite_utils import cli, Database
 from click.testing import CliRunner
 import pathlib
@@ -42,7 +44,7 @@ def test_insert_files():
         one, two, three = (
             rows_by_path["one.txt"],
             rows_by_path["two.txt"],
-            rows_by_path["nested/three.txt"],
+            rows_by_path[os.path.join("nested", "three.txt")],
         )
         assert {
             "content": b"This is file one",
@@ -64,7 +66,7 @@ def test_insert_files():
             "content": b"Three is nested",
             "md5": "12580f341781f5a5b589164d3cd39523",
             "name": "three.txt",
-            "path": "nested/three.txt",
+            "path": os.path.join("nested", "three.txt"),
             "sha256": "6dd45aaaaa6b9f96af19363a92c8fca5d34791d3c35c44eb19468a6a862cc8cd",
             "size": 15,
         }.items() <= three.items()


### PR DESCRIPTION
Hi,

I ran into a problem when trying to create a database from my Apple Healthkit data using [healthkit-to-sqlite](https://github.com/dogsheep/healthkit-to-sqlite). The program crashed because of an invalid insert statement that was generated for table `rDistanceCycling`. 

The actual problem turned out to be in [sqlite-utils](https://github.com/simonw/sqlite-utils). `Table.insert_all` processes the data to be inserted in chunks of rows and checks for every chunk which columns are used, and it will collect all column names in the variable `all_columns`.  The collection of columns is done using a nested list comprehension that is not completely correct. 

I'm using a Windows machine and had to make a few adjustments to the tests in order to be able to run them because they had a posix dependency.

Thanks, kind regards,

Frans

```
# this is a (condensed) chunk of data from my Apple healthkit export that caused the problem.
# the 3 last items in the chunk have additional keys: metadata_HKMetadataKeySyncVersion and metadata_HKMetadataKeySyncIdentifier

chunk = [{'sourceName': 'AppleÂ\xa0Watch van Frans', 'sourceVersion': '7.0.1',
          'device': '<<HKDevice: 0x281cf6c70>, name:Apple Watch, manufacturer:Apple Inc., model:Watch, hardware:Watch3,4, software:7.0.1>',
          'unit': 'km', 'creationDate': '2020-10-10 12:29:09 +0100', 'startDate': '2020-10-10 12:29:06 +0100',
          'endDate': '2020-10-10 12:29:07 +0100', 'value': '0.00518016'},
         {'sourceName': 'AppleÂ\xa0Watch van Frans', 'sourceVersion': '7.0.1',
          'device': '<<HKDevice: 0x281cf6c70>, name:Apple Watch, manufacturer:Apple Inc., model:Watch, hardware:Watch3,4, software:7.0.1>',
          'unit': 'km', 'creationDate': '2020-10-10 12:29:10 +0100', 'startDate': '2020-10-10 12:29:07 +0100',
          'endDate': '2020-10-10 12:29:08 +0100', 'value': '0.00544049'},
         {'sourceName': 'AppleÂ\xa0Watch van Frans', 'sourceVersion': '6.2.6',
          'device': '<<HKDevice: 0x281cf83e0>, name:Apple Watch, manufacturer:Apple Inc., model:Watch, hardware:Watch3,4, software:6.2.6>',
          'unit': 'km', 'creationDate': '2020-10-14 05:54:12 +0100', 'startDate': '2020-07-15 16:40:50 +0100',
          'endDate': '2020-07-15 16:42:49 +0100', 'value': '0.952092', 'metadata_HKMetadataKeySyncVersion': '1',
          'metadata_HKMetadataKeySyncIdentifier': '3:674DBCDB-3FE8-40D1-9FC1-E54A2B413805:616520450.99823:616520569.99360:119'},
         {'sourceName': 'AppleÂ\xa0Watch van Frans', 'sourceVersion': '6.2.6',
          'device': '<<HKDevice: 0x281cf83e0>, name:Apple Watch, manufacturer:Apple Inc., model:Watch, hardware:Watch3,4, software:6.2.6>',
          'unit': 'km', 'creationDate': '2020-10-14 05:54:12 +0100', 'startDate': '2020-07-15 16:42:49 +0100',
          'endDate': '2020-07-15 16:44:51 +0100', 'value': '0.848983', 'metadata_HKMetadataKeySyncVersion': '1',
          'metadata_HKMetadataKeySyncIdentifier': '3:674DBCDB-3FE8-40D1-9FC1-E54A2B413805:616520569.99360:616520691.98826:119'},
         {'sourceName': 'AppleÂ\xa0Watch van Frans', 'sourceVersion': '6.2.6',
          'device': '<<HKDevice: 0x281cf83e0>, name:Apple Watch, manufacturer:Apple Inc., model:Watch, hardware:Watch3,4, software:6.2.6>',
          'unit': 'km', 'creationDate': '2020-10-14 05:54:12 +0100', 'startDate': '2020-07-15 16:44:51 +0100',
          'endDate': '2020-07-15 16:46:50 +0100', 'value': '0.834403', 'metadata_HKMetadataKeySyncVersion': '1',
          'metadata_HKMetadataKeySyncIdentifier': '3:674DBCDB-3FE8-40D1-9FC1-E54A2B413805:616520691.98826:616520810.98305:119'}]



def all_columns_old():
    all_columns = [col for col in chunk[0]]
    all_columns += [column for record in chunk
                           for column in record if column not in all_columns]
    return all_columns


def all_columns_new():
    all_columns = [col for col in chunk[0]]
    for record in chunk:
        all_columns += [column for column in record if column not in all_columns]
    return all_columns



if __name__ == '__main__':
    from pprint import pprint

    print('problem: ')
    pprint(all_columns_old())
    print('\nfix: ')
    pprint(all_columns_new())

```
