### PR TITLE
Add dict type to be mapped as TEXT in sqllite

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -167,6 +167,7 @@ COLUMN_TYPE_MAPPING = {
     int: "INTEGER",
     bool: "INTEGER",
     str: "TEXT",
+    dict: "TEXT",
     bytes.__class__: "BLOB",
     bytes: "BLOB",
     memoryview: "BLOB",
@@ -185,6 +186,7 @@ COLUMN_TYPE_MAPPING = {
     "integer": "INTEGER",
     "float": "FLOAT",
     "blob": "BLOB",
+    
 }
 # If numpy is available, add more types
 if np:


### PR DESCRIPTION
the library deal with Postgres type jsonb as dictionary, add dict type as a TEXT for mapping to sqlite

