### PR TITLE
Extract expand: Support JSON Arrays

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1172,6 +1172,7 @@ class Table(Queryable):
                 self.update(row_pk, {fk_column: new_pk})
             elif isinstance(expanded, list):
                 if not len(expanded):
+                    m21 = True
                     continue
                 elif isinstance(expanded[0], dict):
                     m2m = True

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2092,10 +2092,11 @@ class Table(Queryable):
         lookup=None,
         m2m_table=None,
         alter=False,
+        our_id = None
     ):
         if isinstance(other_table, str):
             other_table = self.db.table(other_table, pk=pk)
-        our_id = self.last_pk
+        our_id = our_id or self.last_pk
         if lookup is not None:
             assert record_or_iterable is None, "Provide lookup= or record, not both"
         else:

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -144,6 +144,10 @@ class InvalidColumns(Exception):
     pass
 
 
+class ExpandError(Exception):
+    pass
+
+
 _COUNTS_TABLE_CREATE_SQL = """
 CREATE TABLE IF NOT EXISTS [{}](
    [table] TEXT PRIMARY KEY,
@@ -1168,6 +1172,9 @@ class Table(Queryable):
                 for new_row in expanded:
                     new_pk = self.db[table].insert(new_row, pk="id", replace=True).last_pk
                     self.update(row_pk, {fk_column: new_pk})
+            else:
+                raise ExpandError("expanded value needs to be list or dict")
+
         # Can drop the original column now
         self.transform(drop=[column])
         # And add that foreign key

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1164,6 +1164,10 @@ class Table(Queryable):
             if isinstance(expanded, dict):
                 new_pk = self.db[table].insert(expanded, pk="id", replace=True).last_pk
                 self.update(row_pk, {fk_column: new_pk})
+            elif isinstance(expanded, list):
+                for new_row in expanded:
+                    new_pk = self.db[table].insert(new_row, pk="id", replace=True).last_pk
+                    self.update(row_pk, {fk_column: new_pk})
         # Can drop the original column now
         self.transform(drop=[column])
         # And add that foreign key


### PR DESCRIPTION
Hi,

I needed to extract data in JSON Arrays to normalize data imports. I've quickly hacked the following together based on #241 which refers to #239 where you, @simonw, wrote:

> Could this handle lists of objects too? That would be pretty amazing - if the column has a [{...}, {...}] list in it could turn that into a many-to-many.

They way this works in my work is that many-to-many relationships are created for anything that maps to an dictionary in a list, and many-to-one relations for everything else (assumed to be scalar values). Not sure what the best approach here would be? Are many-to-one relationships are at all useful here?

What do you think about this approach? I could try to add it to the cli interface and documentation if wanted.

Thanks for this awesome piece of software in any case! :sun_with_face: 