### PR TITLE
Add functionality to read Parquet files.

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -665,6 +665,17 @@ The ``most_common`` and ``least_common`` columns will contain nested JSON arrays
 
 .. _cli_inserting_data:
 
+Inserting Parquet data
+======================
+
+Parquet is a columnar storage format, frequently used in the Hadoop/Spark ecosystem as well as cloud providers.
+Parquet files can be inserted via the ``--parquet`` flag.
+Here's an example::
+
+    $ sqlite-utils insert --parquet data.db data ./data.parquet
+
+Parquet files, along with the data store data types too, thus making the ``--detect-types`` flag redundant, as data types are inferred automatically (using PyArrow)
+
 Inserting JSON data
 ===================
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "click-default-group",
         "tabulate",
         "dateutils",
+        "pyarrow"
     ],
     setup_requires=["pytest-runner"],
     extras_require={

--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -278,3 +278,7 @@ def progressbar(*args, **kwargs):
     else:
         with click.progressbar(*args, **kwargs) as bar:
             yield bar
+
+
+def pyarrow_tuple_as_py(pyarrow_tuple):
+    return tuple(map(lambda f: f.as_py(), pyarrow_tuple))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,8 @@ import os
 import pytest
 from sqlite_utils.utils import sqlite3, find_spatialite
 import textwrap
+from pyarrow import Table
+from pyarrow.parquet import ParquetWriter
 
 from .utils import collapse_whitespace
 
@@ -823,22 +825,45 @@ def test_insert_csv_tsv(content, options, db_path, tmpdir):
 
 
 @pytest.mark.parametrize(
+    "content,options",
+    [
+        ({"foo": [1, 11], "bar": [2, 22], "baz": ["cat,dog", "animal"]}, ["--parquet"])
+    ],
+)
+def test_insert_parquet(content, options, db_path, tmpdir):
+    db = Database(db_path)
+    file_path = str(tmpdir / "insert.parquet")
+    arrow_table = Table.from_pydict(content)
+    ParquetWriter(file_path, arrow_table.schema).write_table(arrow_table)
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "data", file_path] + options,
+        catch_exceptions=False,
+    )
+    assert 0 == result.exit_code
+    assert [{"foo": 1, "bar": 2, "baz": "cat,dog"},
+            {"foo": 11, "bar": 22, "baz": "animal"}] == list(db["data"].rows)
+
+
+@pytest.mark.parametrize(
     "options",
     (
         ["--tsv", "--nl"],
         ["--tsv", "--csv"],
         ["--csv", "--nl"],
         ["--csv", "--nl", "--tsv"],
+        ["--csv", "--nl", "--parquet"],
+        ["--csv", "--parquet"],
     ),
 )
-def test_only_allow_one_of_nl_tsv_csv(options, db_path, tmpdir):
+def test_only_allow_one_of_nl_tsv_csv_parquet(options, db_path, tmpdir):
     file_path = str(tmpdir / "insert.csv-tsv")
     open(file_path, "w").write("foo")
     result = CliRunner().invoke(
         cli.cli, ["insert", db_path, "data", file_path] + options
     )
     assert 0 != result.exit_code
-    assert "Error: Use just one of --nl, --csv or --tsv" == result.output.strip()
+    assert "Error: Use just one of --nl, --csv, --tsv or --parquet" == result.output.strip()
 
 
 def test_insert_replace(db_path, tmpdir):


### PR DESCRIPTION
I needed this for a project of mine, and I thought it'd be useful to have it in sqlite-utils (It's also mentioned in #248 ).
The current implementation works (data is read & data types are inferred correctly.
I've added a single straightforward test case, but @simonw please let me know if there are any non-obvious flags/combinations I should test too.