### PR TITLE
Default values for `--attach` and `--param` options

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1136,6 +1136,7 @@ def drop_view(path, view, ignore, load_extension):
     "--attach",
     type=(str, click.Path(file_okay=True, dir_okay=False, allow_dash=False)),
     multiple=True,
+    default=(),
     help="Additional databases to attach - specify alias and filepath",
 )
 @output_options
@@ -1145,6 +1146,7 @@ def drop_view(path, view, ignore, load_extension):
     "--param",
     multiple=True,
     type=(str, str),
+    default=(),
     help="Named :parameters for SQL query",
 )
 @load_extension_option


### PR DESCRIPTION
It seems that `click` 8.x uses `None` as the default value for `multiple=True` options.

This change makes the code forward-compatible with `click` 8.x.

See this build failure for more info: https://hydra.nixos.org/build/156926608