### PR TITLE
Ignore common generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ venv
 .coverage
 .schema
 .vscode
+.hypothesis
+Pipfile
+Pipfile.lock
+pyproject.toml


### PR DESCRIPTION
Closes #418 

This adds four files to `.gitignore`:

	.hypothesis/
	Pipfile
	Pipfile.lock
	pyproject.toml

Those are all generated in the course of development and testing.