### PR TITLE
search_sql add include_rank option

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2376,6 +2376,7 @@ class Table(Queryable):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         where: Optional[str] = None,
+        include_rank: bool = False,
     ) -> str:
         """ "
         Return SQL string that can be used to execute searches against this table.
@@ -2427,6 +2428,8 @@ class Table(Queryable):
             rank_implementation = "rank_bm25(matchinfo([{}], 'pcnalx'))".format(
                 fts_table
             )
+        if include_rank:
+            columns_with_prefix_sql += ",\n    " + rank_implementation + " rank"
         limit_offset = ""
         if limit is not None:
             limit_offset += " limit {}".format(limit)

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2386,6 +2386,7 @@ class Table(Queryable):
         :param limit: SQL limit
         :param offset: SQL offset
         :param where: Extra SQL fragment for the WHERE clause
+        :param include_rank: Select the search rank column in the final query
         """
         # Pick names for table and rank column that don't clash
         original = "original_" if self.name == "original" else "original"

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -556,6 +556,27 @@ def test_enable_fts_error_message_on_views():
                 "    rank_bm25(matchinfo([books_fts], 'pcnalx'))"
             ),
         ),
+        (
+            {'include_rank': True},
+            "FTS5",
+            (
+                "with original as (\n"
+                "    select\n"
+                "        rowid,\n"
+                "        *\n"
+                "    from [books]\n"
+                ")\n"
+                "select\n"
+                "    [original].*,\n    [books_fts].rank rank\n"
+                "from\n"
+                "    [original]\n"
+                "    join [books_fts] on [original].rowid = [books_fts].rowid\n"
+                "where\n"
+                "    [books_fts] match :query\n"
+                "order by\n"
+                "    [books_fts].rank"
+            ),
+        ),
     ],
 )
 def test_search_sql(kwargs, fts, expected):

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -567,7 +567,8 @@ def test_enable_fts_error_message_on_views():
                 "    from [books]\n"
                 ")\n"
                 "select\n"
-                "    [original].*,\n    [books_fts].rank rank\n"
+                "    [original].*,\n"
+                "    [books_fts].rank rank\n"
                 "from\n"
                 "    [original]\n"
                 "    join [books_fts] on [original].rowid = [books_fts].rowid\n"
@@ -575,6 +576,28 @@ def test_enable_fts_error_message_on_views():
                 "    [books_fts] match :query\n"
                 "order by\n"
                 "    [books_fts].rank"
+            ),
+        ),
+        (
+            {'include_rank': True},
+            "FTS4",
+            (
+                "with original as (\n"
+                "    select\n"
+                "        rowid,\n"
+                "        *\n"
+                "    from [books]\n"
+                ")\n"
+                "select\n"
+                "    [original].*,\n"
+                "    rank_bm25(matchinfo([books_fts], 'pcnalx')) rank\n"
+                "from\n"
+                "    [original]\n"
+                "    join [books_fts] on [original].rowid = [books_fts].rowid\n"
+                "where\n"
+                "    [books_fts] match :query\n"
+                "order by\n"
+                "    rank_bm25(matchinfo([books_fts], 'pcnalx'))"
             ),
         ),
     ],

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -557,7 +557,7 @@ def test_enable_fts_error_message_on_views():
             ),
         ),
         (
-            {'include_rank': True},
+            {"include_rank": True},
             "FTS5",
             (
                 "with original as (\n"
@@ -579,7 +579,7 @@ def test_enable_fts_error_message_on_views():
             ),
         ),
         (
-            {'include_rank': True},
+            {"include_rank": True},
             "FTS4",
             (
                 "with original as (\n"


### PR DESCRIPTION
I haven't tested this yet but wanted to get a heads-up whether this kind of change would be useful or if I should just duplicate the function and tweak it within my code

<!-- readthedocs-preview sqlite-utils start -->
----
:books: Documentation preview :books:: https://sqlite-utils--480.org.readthedocs.build/en/480/

<!-- readthedocs-preview sqlite-utils end -->