### PR TITLE
fix: enable-fts permanently save triggers

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2266,7 +2266,8 @@ class Table(Queryable):
                     new_cols=new_cols,
                 )
             )
-            self.db.executescript(triggers)
+            with self.db.conn:
+                self.db.conn.executescript(triggers)
         return self
 
     def populate_fts(self, columns: Iterable[str]) -> "Table":


### PR DESCRIPTION
I was wondering why my all my databases were giving wild search results. Turns out create_trigger was not sticking!

Running `sqlite-utils triggers x.db` shows `[]` after running `enable-fts` using the python api. Looking at the counts trigger it seems that is the right way to save triggers. triggers show up now

<!-- readthedocs-preview sqlite-utils start -->
----
:books: Documentation preview :books:: https://sqlite-utils--498.org.readthedocs.build/en/498/

<!-- readthedocs-preview sqlite-utils end -->