### PR TITLE
Fix repeated calls to `Table.convert()`

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2664,13 +2664,16 @@ class Table(Queryable):
                     return v
                 return jsonify_if_needed(fn(v))
 
-            self.db.register_function(convert_value)
+            fn_name = fn.__name__
+            if fn_name == '<lambda>':
+                fn_name = f'lambda_{hash(fn)}'
+            self.db.register_function(convert_value, name=fn_name)
             sql = "update [{table}] set {sets}{where};".format(
                 table=self.name,
                 sets=", ".join(
                     [
-                        "[{output_column}] = convert_value([{column}])".format(
-                            output_column=output or column, column=column
+                        "[{output_column}] = {fn_name}([{column}])".format(
+                            output_column=output or column, column=column, fn_name=fn_name
                         )
                         for column in columns
                     ]

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -219,6 +219,11 @@ class AlterError(Exception):
     pass
 
 
+class FunctionAlreadyRegistered(Exception):
+    "A function with this name and arity was already registered"
+    pass
+
+
 class NoObviousTable(Exception):
     "Could not tell which table this operation refers to"
     pass
@@ -409,7 +414,7 @@ class Database:
             fn_name = name or fn.__name__
             arity = len(inspect.signature(fn).parameters)
             if not replace and (fn_name, arity) in self._registered_functions:
-                return fn
+                raise FunctionAlreadyRegistered(f'Already registered function with name "{fn_name}" and identical arity')
             kwargs = {}
             registered = False
             if deterministic:
@@ -434,7 +439,7 @@ class Database:
 
     def register_fts4_bm25(self):
         "Register the ``rank_bm25(match_info)`` function used for calculating relevance with SQLite FTS4."
-        self.register_function(rank_bm25, deterministic=True)
+        self.register_function(rank_bm25, deterministic=True, replace=True)
 
     def attach(self, alias: str, filepath: Union[str, pathlib.Path]):
         """

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -137,3 +137,12 @@ def test_convert_multi_exception(fresh_db):
     table.insert({"title": "Mixed Case"})
     with pytest.raises(BadMultiValues):
         table.convert("title", lambda v: v.upper(), multi=True)
+
+
+def test_convert_repeated(fresh_db):
+    table = fresh_db["table"]
+    col = "num"
+    table.insert({col: 1})
+    table.convert(col, lambda x: x*2)
+    table.convert(col, lambda _x: 0)
+    assert table.get(1) == {col: 0}

--- a/tests/test_register_function.py
+++ b/tests/test_register_function.py
@@ -3,7 +3,7 @@ import pytest
 import sys
 from unittest.mock import MagicMock, call
 from sqlite_utils.utils import sqlite3
-
+from sqlite_utils.db import FunctionAlreadyRegistered
 
 def test_register_function(fresh_db):
     @fresh_db.register_function
@@ -85,9 +85,10 @@ def test_register_function_replace(fresh_db):
     assert "one" == fresh_db.execute("select one()").fetchone()[0]
 
     # This will fail to replace the function:
-    @fresh_db.register_function()
-    def one():  # noqa
-        return "two"
+    with pytest.raises(FunctionAlreadyRegistered):
+        @fresh_db.register_function()
+        def one():  # noqa
+            return "two"
 
     assert "one" == fresh_db.execute("select one()").fetchone()[0]
 
@@ -97,3 +98,11 @@ def test_register_function_replace(fresh_db):
         return "two"
 
     assert "two" == fresh_db.execute("select one()").fetchone()[0]
+
+
+def test_register_function_duplicate(fresh_db):
+    def to_lower(s):
+        return s.lower()
+    fresh_db.register_function(to_lower)
+    with pytest.raises(FunctionAlreadyRegistered):
+        fresh_db.register_function(to_lower)


### PR DESCRIPTION
Fixes #525. All tests pass.

There's perhaps a better way to name lambdas? There could be a collision if a caller passes a function with name like `lambda_123456`.

SQLite [documentation](https://www.sqlite.org/appfunc.html) is a little, ah, lite on function name specs. If there is a character that can be used in place of underscore in a SQLite function name that is not permitted in a Python function identifier then that could be a good way to prevent accidental collisions. (I tried dash, colon, dot, no joy).

Otherwise, there is little chance of this happening and if it should happen the risk is mitigated by now throwing an exception in the case of a (name, arity) collision without `replace=True`.

<!-- readthedocs-preview sqlite-utils start -->
----
:books: Documentation preview :books:: https://sqlite-utils--526.org.readthedocs.build/en/526/

<!-- readthedocs-preview sqlite-utils end -->