### PR TITLE
Add paths for homebrew on Apple silicon

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1407,7 +1407,7 @@ def create_database(path, enable_wal, init_spatialite, load_extension):
 
     # load spatialite from expected locations and initialize metadata
     if init_spatialite:
-        db.init_spatialite()
+        db.init_spatialite(find_spatialite() or load_extension)
 
     db.vacuum()
 
@@ -2902,7 +2902,7 @@ def add_geometry_column(
     # load spatialite, one way or another
     if load_extension:
         _load_extensions(db, load_extension)
-    db.init_spatialite()
+    db.init_spatialite(find_spatialite() or load_extension)
 
     if db[table].add_geometry_column(
         column_name, geometry_type, srid, coord_dimension, not_null
@@ -2934,7 +2934,7 @@ def create_spatial_index(db_path, table, column_name, load_extension):
     # load spatialite
     if load_extension:
         _load_extensions(db, load_extension)
-    db.init_spatialite()
+    db.init_spatialite(find_spatialite() or load_extension)
 
     if column_name not in db[table].columns_dict:
         raise click.ClickException(

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2876,7 +2876,6 @@ class Table(Queryable):
                         self.add_missing_columns(chunk)
                         result = self.db.execute(query, params)
                     elif e.args[0] == "too many SQL variables":
-
                         first_half = chunk[: len(chunk) // 2]
                         second_half = chunk[len(chunk) // 2 :]
 

--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -28,6 +28,8 @@ except ImportError:
 SPATIALITE_PATHS = (
     "/usr/lib/x86_64-linux-gnu/mod_spatialite.so",
     "/usr/local/lib/mod_spatialite.dylib",
+    "/usr/local/lib/mod_spatialite.so",
+    "/opt/homebrew/lib/mod_spatialite.dylib",
 )
 
 # Mainly so we can restore it if needed in the tests:

--- a/tests/test_gis.py
+++ b/tests/test_gis.py
@@ -234,3 +234,30 @@ def test_cli_create_spatial_index(tmpdir):
     assert 0 == result.exit_code
 
     assert "idx_locations_geometry" in db.table_names()
+
+
+def test_cli_create_spatial_index_with_path(tmpdir):
+    # create a rowid table with one column
+    db_path = tmpdir / "spatial.db"
+    db = Database(str(db_path))
+    db.init_spatialite()
+
+    table = db["locations"].create({"name": str})
+    table.add_geometry_column("geometry", "POINT")
+
+    path = find_spatialite()
+    result = CliRunner().invoke(
+        cli,
+        [
+            "create-spatial-index",
+            str(db_path),
+            table.name,
+            "geometry",
+            "--load-extension",
+            path,
+        ],
+    )
+
+    assert 0 == result.exit_code
+
+    assert "idx_locations_geometry" in db.table_names()


### PR DESCRIPTION
This also passes in the extension path when specified in GIS methods. Wherever we know an extension path, we use `db.init_spatialite(find_spatialite() or load_extension)`.

<!-- readthedocs-preview sqlite-utils start -->
----
:books: Documentation preview :books:: https://sqlite-utils--531.org.readthedocs.build/en/531/

<!-- readthedocs-preview sqlite-utils end -->