### PR TITLE
Add paths for homebrew on Apple silicon

### DIFF
--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -24,10 +24,11 @@ except ImportError:
 
     OperationalError = sqlite3.OperationalError
 
-
 SPATIALITE_PATHS = (
     "/usr/lib/x86_64-linux-gnu/mod_spatialite.so",
     "/usr/local/lib/mod_spatialite.dylib",
+    "/usr/local/lib/mod_spatialite.so",
+    "/opt/homebrew/lib/mod_spatialite.dylib",
 )
 
 # Mainly so we can restore it if needed in the tests:


### PR DESCRIPTION
Does what it says and nothing else. This is the same set of paths as Datasette uses.

<!-- readthedocs-preview sqlite-utils start -->
----
:books: Documentation preview :books:: https://sqlite-utils--536.org.readthedocs.build/en/536/

<!-- readthedocs-preview sqlite-utils end -->