### PR TITLE
feat: Implement a prepare_connection plugin hook

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -128,7 +128,7 @@ aggregates and collations. For example:
         )
 
 This registers a SQL function called ``hello`` which takes a single
-argument and can be called like this::
+argument and can be called like this:
 
 .. code-block:: sql
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -84,7 +84,7 @@ Your command will also be listed in the output of ``sqlite-utils --help``.
 Plugin hooks
 ------------
 
-Plugin hooks allow ``sqlite-utils`` to be customized. There is currently one hook.
+Plugin hooks allow ``sqlite-utils`` to be customized.
 
 .. _plugins_hooks_register_commands:
 
@@ -107,3 +107,29 @@ Example implementation:
             "Say hello world"
             click.echo("Hello world!")
 
+prepare_connection(conncl)
+~~~~~~~~~~~~~~~~~~~~~~
+
+This hook is called when a new SQLite database connection is created. You can
+use it to `register custom SQL functions <https://docs.python.org/2/library/sqlite3.html#sqlite3.Connection.create_function>`_,
+aggregates and collations. For example:
+
+
+Example implementation:
+
+.. code-block:: python
+
+    import click
+    import sqlite_utils
+
+    @sqlite_utils.hookimpl
+    def prepare_connection(self, conn):
+        conn.create_function(
+          "hello", 1, lambda name: f"Hello, {name}!"
+        )
+
+This registers a SQL function called ``hello`` which takes a single
+argument and can be called like this::
+
+.. code-block:: sql
+    select hello("world"); -- "Hello, world!"

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -107,8 +107,10 @@ Example implementation:
             "Say hello world"
             click.echo("Hello world!")
 
-prepare_connection(conncl)
-~~~~~~~~~~~~~~~~~~~~~~
+.. _plugins_hooks_prepare_connection:
+
+prepare_connection(conn)
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 This hook is called when a new SQLite database connection is created. You can
 use it to `register custom SQL functions <https://docs.python.org/2/library/sqlite3.html#sqlite3.Connection.create_function>`_,

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -123,7 +123,7 @@ Example implementation:
     import sqlite_utils
 
     @sqlite_utils.hookimpl
-    def prepare_connection(self, conn):
+    def prepare_connection(conn):
         conn.create_function(
           "hello", 1, lambda name: f"Hello, {name}!"
         )

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -116,9 +116,6 @@ This hook is called when a new SQLite database connection is created. You can
 use it to `register custom SQL functions <https://docs.python.org/2/library/sqlite3.html#sqlite3.Connection.create_function>`_,
 aggregates and collations. For example:
 
-
-Example implementation:
-
 .. code-block:: python
 
     import click
@@ -134,4 +131,5 @@ This registers a SQL function called ``hello`` which takes a single
 argument and can be called like this::
 
 .. code-block:: sql
+
     select hello("world"); -- "Hello, world!"

--- a/sqlite_utils/__init__.py
+++ b/sqlite_utils/__init__.py
@@ -1,6 +1,6 @@
-from .db import Database
 from .utils import suggest_column_types
 from .hookspecs import hookimpl
 from .hookspecs import hookspec
+from .db import Database
 
 __all__ = ["Database", "suggest_column_types", "hookimpl", "hookspec"]

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -37,6 +37,7 @@ from typing import (
     Tuple,
 )
 import uuid
+from sqlite_utils.plugins import pm
 
 try:
     from sqlite_dump import iterdump
@@ -341,6 +342,8 @@ class Database:
             self.execute("PRAGMA recursive_triggers=on;")
         self._registered_functions: set = set()
         self.use_counts_table = use_counts_table
+
+        pm.hook.prepare_connection(conn=self.conn)
 
     def close(self):
         "Close the SQLite connection, and the underlying database file"

--- a/sqlite_utils/hookspecs.py
+++ b/sqlite_utils/hookspecs.py
@@ -8,3 +8,8 @@ hookimpl = HookimplMarker("sqlite_utils")
 @hookspec
 def register_commands(cli):
     """Register additional CLI commands, e.g. 'sqlite-utils mycommand ...'"""
+
+
+@hookspec
+def prepare_connection(conn):
+    """Modify SQLite connection in some way e.g. register custom SQL functions"""


### PR DESCRIPTION
Just like the [Datasette prepare_connection hook](https://docs.datasette.io/en/stable/plugin_hooks.html#prepare-connection-conn-database-datasette), this PR adds a similar hook for the `sqlite-utils` plugin system. 

The sole argument is `conn`, since I don't believe a `database` or `datasette` argument would be relevant here. 

I want to do this so I can release `sqlite-utils` plugins for my [SQLite extensions](https://github.com/asg017/sqlite-ecosystem), similar to the Datasette plugins I've release for them. 

An example plugin: https://gist.github.com/asg017/d7cdf0d56e2be87efda28cebee27fa3c

```bash
$ sqlite-utils install https://gist.github.com/asg017/d7cdf0d56e2be87efda28cebee27fa3c/archive/5f5ad549a40860787629c69ca120a08c32519e99.zip

$ sqlite-utils memory 'select hello("alex") as response'
[{"response": "Hello, alex!"}]
```
Refs:
- #574 

<!-- readthedocs-preview sqlite-utils start -->
----
:books: Documentation preview :books:: https://sqlite-utils--573.org.readthedocs.build/en/573/

<!-- readthedocs-preview sqlite-utils end -->