### PR TITLE
Fixes mapping for time fields related to mysql, closes #522

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -187,6 +187,7 @@ COLUMN_TYPE_MAPPING = {
     datetime.datetime: "TEXT",
     datetime.date: "TEXT",
     datetime.time: "TEXT",
+    datetime.timedelta: "TEXT",
     decimal.Decimal: "FLOAT",
     None.__class__: "TEXT",
     uuid.UUID: "TEXT",
@@ -3758,6 +3759,8 @@ def jsonify_if_needed(value):
         return json.dumps(value, default=repr, ensure_ascii=False)
     elif isinstance(value, (datetime.time, datetime.date, datetime.datetime)):
         return value.isoformat()
+    elif isinstance(value, datetime.timedelta):
+        return str(value)
     elif isinstance(value, uuid.UUID):
         return str(value)
     else:


### PR DESCRIPTION
Adds `COLUMN_TYPE_MAPPING` for `TIME` fields that are mapped as `datetime.timedelta` for MySQL and json represantation for `datetime.timedelta` in order to fix #522

<!-- readthedocs-preview sqlite-utils start -->
----
:books: Documentation preview :books:: https://sqlite-utils--596.org.readthedocs.build/en/596/

<!-- readthedocs-preview sqlite-utils end -->