### PR TITLE
Add spatialite arm64 linux path

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -538,7 +538,7 @@ class Database:
 
     def quote(self, value: str) -> str:
         """
-        Apply SQLite string quoting to a value, including wrappping it in single quotes.
+        Apply SQLite string quoting to a value, including wrapping it in single quotes.
 
         :param value: String to quote
         """

--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -33,6 +33,7 @@ except ImportError:
 
 SPATIALITE_PATHS = (
     "/usr/lib/x86_64-linux-gnu/mod_spatialite.so",
+    "/usr/lib/aarch64-linux-gnu/mod_spatialite.so",
     "/usr/local/lib/mod_spatialite.dylib",
     "/usr/local/lib/mod_spatialite.so",
     "/opt/homebrew/lib/mod_spatialite.dylib",


### PR DESCRIPTION
According to both [Debian](https://packages.debian.org/bookworm/arm64/libsqlite3-mod-spatialite/filelist) and [Ubuntu](https://packages.ubuntu.com/mantic/arm64/libsqlite3-mod-spatialite/filelist), the correct “target triple” for arm64 is `aarch64-linux-gnu`, so we should be looking in `/usr/lib/aarch64-linux-gnu` for `mod_spatialite.so`.

I can confirm that on both of my Debian arm64 SBCs, `libsqlite3-mod-spatialite` installs to that path.

```
$ ls -l /usr/lib/*/*spatial*
lrwxrwxrwx 1 root root      23 Dec  1  2022 /usr/lib/aarch64-linux-gnu/mod_spatialite.so -> mod_spatialite.so.7.1.0
lrwxrwxrwx 1 root root      23 Dec  1  2022 /usr/lib/aarch64-linux-gnu/mod_spatialite.so.7 -> mod_spatialite.so.7.1.0
-rw-r--r-- 1 root root 7348584 Dec  1  2022 /usr/lib/aarch64-linux-gnu/mod_spatialite.so.7.1.0
```

This is a set of before and after snippets of pytest’s output for this PR.

### Before

```
$ pytest
tests/test_get.py ......                                                 [ 73%]
tests/test_gis.py ssssssssssss                                           [ 75%]
tests/test_hypothesis.py ....                                            [ 75%]
```

### After

```
$ pytest
tests/test_get.py ......                                                 [ 73%]
tests/test_gis.py ............                                           [ 75%]
tests/test_hypothesis.py ....                                            [ 75%]
```


Issue: #599

<!-- readthedocs-preview sqlite-utils start -->
----
:books: Documentation preview :books:: https://sqlite-utils--600.org.readthedocs.build/en/600/

<!-- readthedocs-preview sqlite-utils end -->