### PR TITLE
Recreate indexes when calling transform when possible and raise an er…

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -1402,6 +1402,8 @@ To keep the original table around instead of dropping it, pass the ``keep_table=
 
     table.transform(types={"age": int}, keep_table="original_table")
 
+This method raises a ``sqlite_utils.db.TransformError`` exception if the table cannot be transformed, usually because there are existing constraints or indexes that are incompatible with modifications to the columns.
+
 .. _python_api_transform_alter_column_types:
 
 Altering column types

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -156,6 +156,10 @@ XIndexColumn = namedtuple(
 Trigger = namedtuple("Trigger", ("name", "table", "sql"))
 
 
+class TransformError(Exception):
+    pass
+
+
 ForeignKeyIndicator = Union[
     str,
     ForeignKey,
@@ -1974,20 +1978,22 @@ class Table(Queryable):
                     """SELECT sql FROM sqlite_master WHERE type = 'index' AND name = :index_name;""",
                     {"index_name": index.name},
                 ).fetchall()[0][0]
-                assert index_sql is not None, (
-                    f"Index '{index.name}' on table '{self.name}' does not have a "
-                    "CREATE INDEX statement. You must manually drop this index prior to running this "
-                    "transformation and manually recreate the new index after running this transformation."
-                )
+                if index_sql is None:
+                    raise TransformError(
+                        f"Index '{index.name}' on table '{self.name}' does not have a "
+                        "CREATE INDEX statement. You must manually drop this index prior to running this "
+                        "transformation and manually recreate the new index after running this transformation."
+                    )
                 if keep_table:
                     sqls.append(f"DROP INDEX IF EXISTS [{index.name}];")
                 for col in index.columns:
-                    assert col not in rename.keys() and col not in drop, (
-                        f"Index '{index.name}' column '{col}' is not in updated table '{self.name}'. "
-                        f"You must manually drop this index prior to running this transformation "
-                        f"and manually recreate the new index after running this transformation. "
-                        f"The original index sql statement is: `{index_sql}`. No changes have been applied to this table."
-                    )
+                    if col in rename.keys() or col in drop:
+                        raise TransformError(
+                            f"Index '{index.name}' column '{col}' is not in updated table '{self.name}'. "
+                            f"You must manually drop this index prior to running this transformation "
+                            f"and manually recreate the new index after running this transformation. "
+                            f"The original index sql statement is: `{index_sql}`. No changes have been applied to this table."
+                        )
                 sqls.append(index_sql)
         return sqls
 

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1975,7 +1975,7 @@ class Table(Queryable):
                     {"index_name": index.name},
                 ).fetchall()[0][0]
                 assert index_sql is not None, (
-                    f"Index '{index}' on table '{self.name}' does not have a "
+                    f"Index '{index.name}' on table '{self.name}' does not have a "
                     "CREATE INDEX statement. You must manually drop this index prior to running this "
                     "transformation and manually recreate the new index after running this transformation."
                 )

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1969,7 +1969,7 @@ class Table(Queryable):
         )
         # Re-add existing indexes
         for index in self.indexes:
-            if index.origin not in ("pk"):
+            if index.origin != "pk":
                 index_sql = self.db.execute(
                     """SELECT sql FROM sqlite_master WHERE type = 'index' AND name = :index_name;""",
                     {"index_name": index.name},

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -551,6 +551,8 @@ def test_transform_strict(fresh_db, strict):
     ],
 )
 def test_transform_indexes(fresh_db, indexes, transform_params):
+    # https://github.com/simonw/sqlite-utils/issues/633
+    # New table should have same indexes as old table after transformation
     dogs = fresh_db["dogs"]
     dogs.insert({"id": 1, "name": "Cleo", "age": 5, "breed": "Labrador"}, pk="id")
 
@@ -617,6 +619,7 @@ def test_transform_retains_indexes_with_foreign_keys(fresh_db):
     ],
 )
 def test_transform_with_indexes_errors(fresh_db, transform_params):
+    # Should error with a compound (name, age) index if age is renamed or dropped
     dogs = fresh_db["dogs"]
     dogs.insert({"id": 1, "name": "Cleo", "age": 5}, pk="id")
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,4 @@
-from sqlite_utils.db import ForeignKey
+from sqlite_utils.db import ForeignKey, TransformError
 from sqlite_utils.utils import OperationalError
 import pytest
 
@@ -625,7 +625,7 @@ def test_transform_with_indexes_errors(fresh_db, transform_params):
 
     dogs.create_index(["name", "age"])
 
-    with pytest.raises(AssertionError) as excinfo:
+    with pytest.raises(TransformError) as excinfo:
         dogs.transform(**transform_params)
 
     assert (
@@ -650,7 +650,7 @@ def test_transform_with_unique_constraint_implicit_index(fresh_db):
     dogs.insert({"id": 1, "name": "Cleo", "age": 5})
 
     # Attempt to transform the table without modifying 'name'
-    with pytest.raises(AssertionError) as excinfo:
+    with pytest.raises(TransformError) as excinfo:
         dogs.transform(types={"age": str})
 
     assert (


### PR DESCRIPTION
Recreate indexes when calling transform when possible and raise an error when they cannot be retained automatically.

This resolves my initial problem: 'After creating a table with an index, if you add a foreign key constraint to the table it drops existing non-related indexes.'

GH Issue:
- https://github.com/simonw/sqlite-utils/issues/633

My explanation, thoughts and reasoning:

I think it is best to try and preserve existing indexes and fail loudly if they are unable to be recreated automatically. At the very least I believe you should be warned if they are not going to be recreated.

Below is my proposed solution with code:

1) If a table is kept it will automatically drop the original index. To be able to create the index on the new table using the original CREATE INDEX statement the original index must be dropped. I think it's a reasonable default for the 'kept' table to lose its indexes. I suspect the most common reason to keep the original table is for 'backup' purposes. It would also be difficult to automatically create updated CREATE INDEX statements for the kept renamed table where the statements are more complicated.

2) If a column exists in the original index but not in the new table, you should have to manually recreate the index as desired. In complicated CREATE INDEX statements it is difficult to automatically replace or remove columns correctly. Failing before any operations have been completed is desired because it allows you to know there will be a problem prior to the SQL statements being executed allowing you to collect the required information required to manually update the indexes prior to any actions taking place as well as not leaving your database in a potentially invalid state.



<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--634.org.readthedocs.build/en/634/

<!-- readthedocs-preview sqlite-utils end -->