### PR TITLE
typo in command name

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2796,7 +2796,7 @@ To enable this feature you will need to install the ``trogon`` dependency. You c
 
 .. code-block:: bash
 
-    sqite-utils install trogon
+    sqlite-utils install trogon
 
 Once installed, running the ``sqlite-utils tui`` command will launch the TUI interface:
 


### PR DESCRIPTION


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--640.org.readthedocs.build/en/640/

<!-- readthedocs-preview sqlite-utils end -->