### PR TITLE
docs: open tutorial in marimo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![codecov](https://codecov.io/gh/simonw/sqlite-utils/branch/main/graph/badge.svg)](https://codecov.io/gh/simonw/sqlite-utils)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/simonw/sqlite-utils/blob/main/LICENSE)
 [![discord](https://img.shields.io/discord/823971286308356157?label=discord)](https://discord.gg/Ass7bCAMDw)
+[![Tutorial](https://marimo.io/shield.svg)](https://marimo.app/github.com/simonw/sqlite-utils/blob/main/docs/tutorial.ipynb)
+
 
 Python CLI utility and library for manipulating SQLite databases.
 


### PR DESCRIPTION
This PR adds an "open in marimo" badge to open the tutorial Jupyter notebook in marimo's online (Wasm) playground.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--649.org.readthedocs.build/en/649/

<!-- readthedocs-preview sqlite-utils end -->