### PR TITLE
Add a type hint for `db.close()`

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -369,7 +369,7 @@ class Database:
             pm.hook.prepare_connection(conn=self.conn)
         self.strict = strict
 
-    def close(self):
+    def close(self) -> None:
         "Close the SQLite connection, and the underlying database file"
         self.conn.close()
 


### PR DESCRIPTION
Closes:
- #662

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--663.org.readthedocs.build/en/663/

<!-- readthedocs-preview sqlite-utils end -->