### PR TITLE
feat: add URI filename support

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -11,6 +11,41 @@ Once :ref:`installed <installation>` the tool should be available as ``sqlite-ut
 .. contents:: :local:
    :class: this-will-duplicate-information-and-it-is-still-useful-here
 
+.. _cli_uri_filenames:
+
+URI filenames
+=============
+
+``sqlite-utils`` supports `SQLite URI filenames <https://www.sqlite.org/uri.html>`__, which allow you to open databases with special parameters.
+
+A URI filename starts with ``file:`` and can include query parameters to control database behavior:
+
+.. code-block:: bash
+
+    sqlite-utils tables 'file:data.db?mode=ro'
+
+Common URI parameters include:
+
+- ``mode=ro`` - Open database read-only
+- ``mode=rw`` - Open read-write (default)
+- ``mode=rwc`` - Open read-write and create if it doesn't exist
+- ``mode=memory`` - Open as an in-memory database
+- ``immutable=1`` - Open as immutable (SQLite will not try to modify the file)
+
+Example opening a database as read-only and immutable:
+
+.. code-block:: bash
+
+    sqlite-utils query 'file:data.db?mode=ro&immutable=1' "select * from items"
+
+This is particularly useful for:
+
+- Safely querying databases without risk of modification
+- Opening databases on read-only filesystems
+- Sharing databases between multiple processes with ``immutable=1``
+
+URI filenames work with all ``sqlite-utils`` commands that accept database paths.
+
 .. _cli_query:
 
 Running SQL queries
@@ -504,7 +539,7 @@ By default, ``sqlite-utils memory`` will attempt to detect the incoming data for
 You can instead specify an explicit format by adding a ``:csv``, ``:tsv``, ``:json`` or ``:nl`` (for newline-delimited JSON) suffix to the filename. For example:
 
 .. code-block:: bash
-    
+
     sqlite-utils memory one.dat:csv two.dat:nl \
       "select * from one union select * from two"
 
@@ -1153,7 +1188,7 @@ You can also pipe ``sqlite-utils`` together to create a new SQLite database file
     sqlite-utils sf-trees.db \
         "select TreeID, qAddress, Latitude, Longitude from Street_Tree_List" --nl \
       | sqlite-utils insert saved.db trees - --nl
-    
+
 .. code-block:: bash
 
     sqlite-utils saved.db "select * from trees limit 5" --csv
@@ -2729,7 +2764,7 @@ You can convert an existing table to a geographic table by adding a geometry col
 
 The table (``locations`` in the example above) must already exist before adding a geometry column. Use ``sqlite-utils create-table`` first, then ``add-geometry-column``.
 
-Use the ``--type`` option to specify a geometry type. By default, ``add-geometry-column`` uses a generic ``GEOMETRY``, which will work with any type, though it may not be supported by some desktop GIS applications. 
+Use the ``--type`` option to specify a geometry type. By default, ``add-geometry-column`` uses a generic ``GEOMETRY``, which will work with any type, though it may not be supported by some desktop GIS applications.
 
 Eight (case-insensitive) types are allowed:
 

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -93,6 +93,16 @@ Instead of a file path you can pass in an existing SQLite connection:
 
     db = Database(sqlite3.connect("my_database.db"))
 
+You can also use `SQLite URI filenames <https://www.sqlite.org/uri.html>`__ to open databases with special parameters:
+
+.. code-block:: python
+
+    # Open database in read-only mode
+    db = Database("file:data.db?mode=ro")
+
+    # Open as read-only and immutable
+    db = Database("file:data.db?mode=ro&immutable=1")
+
 If you want to create an in-memory database, you can do so like this:
 
 .. code-block:: python

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -1,0 +1,177 @@
+"""
+Tests for SQLite URI filename support
+https://github.com/simonw/sqlite-utils/issues/650
+"""
+import pytest
+import sqlite_utils
+from sqlite_utils import Database
+from click.testing import CliRunner
+from sqlite_utils import cli
+import pathlib
+import tempfile
+import os
+
+
+@pytest.fixture
+def test_db_file(tmp_path):
+    """Create a test database file with some data"""
+    db_path = tmp_path / "test.db"
+    db = Database(str(db_path))
+    db["test_table"].insert_all([
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+        {"id": 3, "name": "Charlie"},
+    ], pk="id")
+    db.close()
+    return db_path
+
+
+def test_database_class_with_uri(test_db_file):
+    """Test that Database class can open a URI"""
+    # Test read-only mode
+    uri = f"file:{test_db_file}?mode=ro"
+    db = Database(uri)
+    rows = list(db["test_table"].rows)
+    assert len(rows) == 3
+    assert rows[0]["name"] == "Alice"
+    db.close()
+
+
+def test_database_class_with_uri_immutable(test_db_file):
+    """Test that Database class can open a URI with immutable flag"""
+    uri = f"file:{test_db_file}?immutable=1"
+    db = Database(uri)
+    rows = list(db["test_table"].rows)
+    assert len(rows) == 3
+    db.close()
+
+
+def test_database_class_with_uri_multiple_params(test_db_file):
+    """Test URI with multiple query parameters"""
+    uri = f"file:{test_db_file}?mode=ro&immutable=1"
+    db = Database(uri)
+    rows = list(db["test_table"].rows)
+    assert len(rows) == 3
+    db.close()
+
+
+def test_cli_tables_with_uri(test_db_file):
+    """Test that tables command works with URI"""
+    runner = CliRunner()
+    uri = f"file:{test_db_file}?mode=ro"
+    result = runner.invoke(cli.cli, ["tables", uri, "--csv"])
+    assert result.exit_code == 0
+    assert "test_table" in result.output
+
+
+def test_cli_tables_with_uri_immutable(test_db_file):
+    """Test that tables command works with URI and immutable flag"""
+    runner = CliRunner()
+    uri = f"file:{test_db_file}?mode=ro&immutable=1"
+    result = runner.invoke(cli.cli, ["tables", uri])
+    assert result.exit_code == 0
+    assert "test_table" in result.output
+
+
+def test_cli_query_with_uri(test_db_file):
+    """Test that query command works with URI"""
+    runner = CliRunner()
+    uri = f"file:{test_db_file}?mode=ro"
+    result = runner.invoke(cli.cli, ["query", uri, "SELECT * FROM test_table"])
+    assert result.exit_code == 0
+    assert "Alice" in result.output
+    assert "Bob" in result.output
+
+
+def test_cli_query_with_uri_multiple_params(test_db_file):
+    """Test that query command works with URI with multiple parameters"""
+    runner = CliRunner()
+    uri = f"file:{test_db_file}?mode=ro&immutable=1"
+    result = runner.invoke(cli.cli, ["query", uri, "SELECT name FROM test_table WHERE id = 1"])
+    assert result.exit_code == 0
+    assert "Alice" in result.output
+
+
+def test_cli_rows_with_uri(test_db_file):
+    """Test that rows command works with URI"""
+    runner = CliRunner()
+    uri = f"file:{test_db_file}?mode=ro"
+    result = runner.invoke(cli.cli, ["rows", uri, "test_table"])
+    assert result.exit_code == 0
+    assert "Alice" in result.output
+
+
+def test_uri_with_relative_path(tmp_path):
+    """Test URI with relative path"""
+    # Create a database in a subdirectory
+    db_path = tmp_path / "test.db"
+    db = Database(str(db_path))
+    db["test_table"].insert({"id": 1, "name": "Test"})
+    db.close()
+
+    # Test with relative path in URI
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        uri = "file:test.db?mode=ro"
+        db = Database(uri)
+        rows = list(db["test_table"].rows)
+        assert len(rows) == 1
+        db.close()
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_uri_with_absolute_path(test_db_file):
+    """Test URI with absolute path"""
+    # Use triple slash for absolute path
+    uri = f"file:///{test_db_file}?mode=ro"
+    db = Database(uri)
+    rows = list(db["test_table"].rows)
+    assert len(rows) == 3
+    db.close()
+
+
+def test_regular_path_still_works(test_db_file):
+    """Ensure regular file paths still work after URI changes"""
+    # Test Database class
+    db = Database(str(test_db_file))
+    rows = list(db["test_table"].rows)
+    assert len(rows) == 3
+    db.close()
+
+    # Test CLI
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["tables", str(test_db_file)])
+    assert result.exit_code == 0
+    assert "test_table" in result.output
+
+
+def test_cli_insert_with_uri_fails_readonly():
+    """Test that insert fails with read-only URI"""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Create a database first
+        db = Database("test.db")
+        db["test_table"].insert({"id": 1, "name": "Test"})
+        db.close()
+
+        # Try to insert with read-only URI
+        uri = "file:test.db?mode=ro"
+        result = runner.invoke(cli.cli, ["insert", uri, "test_table", "-"],
+                              input='{"id": 2, "name": "Another"}')
+        assert result.exit_code != 0
+        assert "readonly" in result.output.lower() or "read-only" in result.output.lower() or "attempt to write" in result.output.lower()
+
+
+def test_nonexistent_file_with_uri_mode_rwc():
+    """Test that URI with mode=rwc can create new database"""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        uri = "file:newdb.db?mode=rwc"
+        # This should create the database and table
+        result = runner.invoke(cli.cli, ["insert", uri, "test_table", "-"],
+                              input='{"id": 1, "name": "Test"}')
+        assert result.exit_code == 0
+        # Verify the database was created
+        assert os.path.exists("newdb.db")


### PR DESCRIPTION
fix #650 

This code was generated with VS Code Copilot agent and Sonnet-4.5.

I think it did its job quite well.

Generated PR message below

---

## Add SQLite URI filename support

Implements support for SQLite URI filenames across CLI and Python API (fixes #650).

### Changes

**sqlite_utils/db.py:**
- Modified `Database.__init__()` to detect URI filenames (strings starting with ) and pass `uri=True` parameter to `sqlite3.connect()`

**sqlite_utils/cli.py:**
- Added `DatabasePath` class extending `click.Path` to handle URI filenames
- URIs bypass file existence validation while maintaining normal validation for regular paths
- Replaced all database path parameters throughout CLI with `DatabasePath`

**tests/test_uri.py:**
- Added comprehensive test coverage for URI functionality
- Tests include: read-only mode, immutable flag, multiple parameters, CLI commands, path validation

**Documentation:**
- Added URI filenames section to CLI documentation
- Added URI examples to Python API documentation

### Usage

CLI:
```bash
sqlite-utils tables 'file:data.db?mode=ro&immutable=1'
sqlite-utils query 'file:data.db?mode=ro' "SELECT * FROM items"
```

Python API:
```python
from sqlite_utils import Database
db = Database("file:data.db?mode=ro&immutable=1")
```

### Testing

All existing tests pass. Added 13 new tests covering URI functionality. Type checking passes with mypy.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--670.org.readthedocs.build/en/670/

<!-- readthedocs-preview sqlite-utils end -->