### PR TITLE
Allow callable references in sqlite-utils convert, closes #686

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1849,7 +1849,19 @@ These recipes can be used in the code passed to ``sqlite-utils convert`` like th
     sqlite-utils convert my.db mytable mycolumn \
       'r.jsonsplit(value)'
 
-To use any of the documented parameters, do this:
+You can also pass the recipe function directly without the ``(value)`` part - sqlite-utils will detect that it is a callable and use it automatically:
+
+.. code-block:: bash
+
+    sqlite-utils convert my.db mytable mycolumn r.parsedate
+
+This shorter syntax works for any callable, including functions from imported modules:
+
+.. code-block:: bash
+
+    sqlite-utils convert my.db mytable mycolumn json.loads --import json
+
+To use any of the documented parameters, use the full function call syntax:
 
 .. code-block:: bash
 


### PR DESCRIPTION
- https://github.com/simonw/sqlite-utils/issues/686

This allows users to pass just a callable reference like `r.parsedate`
instead of `r.parsedate(value)` to the convert command. The code now
detects when the input evaluates to a callable and uses it directly.

Examples that now work:
- sqlite-utils convert my.db table col r.parsedate
- sqlite-utils convert my.db table col json.loads --import json

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--690.org.readthedocs.build/en/690/

<!-- readthedocs-preview sqlite-utils end -->

Claude Code for web prompt (I literally just pasted in the URL to the issue):

> `https://github.com/simonw/sqlite-utils/issues/686`