### PR TITLE
Add automatic JSON deserialization feature

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -176,6 +176,19 @@ You can use the ``--json-cols`` option to automatically detect these JSON column
         }
     ]
 
+.. _cli_use_json_converters:
+
+Automatic JSON deserialization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use the ``--use-json-converters`` flag to automatically deserialize columns that are declared as ``JSON`` (or inferred as such during insertion).
+
+.. code-block:: bash
+
+    sqlite-utils query dogs.db "select * from dogs" --use-json-converters
+
+If you use this flag with ``insert``, ``upsert`` or ``bulk``, it will also cause nested Python dictionaries or lists to be stored in columns with a declared type of ``JSON`` rather than ``TEXT``.
+
 .. _cli_query_csv:
 
 Returning CSV or TSV
@@ -1935,7 +1948,7 @@ Most of the time creating tables by inserting example data is the quickest appro
 
 This will create a table called ``mytable`` with two columns - an integer ``id`` column and a text ``name`` column. It will set the ``id`` column to be the primary key.
 
-You can pass as many column-name column-type pairs as you like. Valid types are ``integer``, ``text``, ``float`` and ``blob``.
+You can pass as many column-name column-type pairs as you like. Valid types are ``integer``, ``text``, ``float``, ``blob`` and ``json``.
 
 Pass ``--pk`` more than once for a compound primary key that covers multiple columns.
 

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -117,6 +117,14 @@ By default, any :ref:`sqlite-utils plugins <plugins>` that implement the :ref:`p
 
     db = Database(memory=True, execute_plugins=False)
 
+You can pass ``use_json_converters=True`` to enable automatic JSON conversion for columns declared as ``JSON``. This will register a custom converter with SQLite that uses ``json.loads()`` to deserialize values:
+
+.. code-block:: python
+
+    db = Database("my_database.db", use_json_converters=True)
+
+When this is enabled, Python ``dict``, ``list`` and ``tuple`` values will be stored in columns with a declared type of ``JSON``, and those columns will be automatically deserialized back into Python objects when you retrieve them from the database.
+
 You can pass ``strict=True`` to enable `SQLite STRICT mode <https://www.sqlite.org/stricttables.html>`__ for all tables created using this database object:
 
 .. code-block:: python

--- a/tests/test_cli_json_converters.py
+++ b/tests/test_cli_json_converters.py
@@ -1,0 +1,82 @@
+import pytest
+from click.testing import CliRunner
+from sqlite_utils import cli, Database
+import json
+
+def test_insert_json_converters(tmpdir):
+    db_path = str(tmpdir / "test.db")
+    runner = CliRunner()
+    
+    # Input data with nested structure
+    data = [{"id": 1, "nested": {"foo": "bar"}}, {"id": 2, "nested": {"baz": 123}}]
+    input_str = json.dumps(data)
+    
+    # Insert without --use-json-converters
+    result = runner.invoke(cli.cli, ["insert", db_path, "t1", "-"], input=input_str)
+    assert result.exit_code == 0
+    
+    db = Database(db_path)
+    # Access column by name to be robust against ordering changes
+    assert next(c for c in db["t1"].columns if c.name == "nested").type == "TEXT"
+    row = db["t1"].get(1)
+    assert isinstance(row["nested"], str)
+    
+    # Insert WITH --use-json-converters
+    result = runner.invoke(cli.cli, ["insert", db_path, "t2", "-", "--use-json-converters"], input=input_str)
+    assert result.exit_code == 0
+    
+    # We need to open with use_json_converters=True to see the effect on get()
+    db_json = Database(db_path, use_json_converters=True)
+    assert next(c for c in db_json["t2"].columns if c.name == "nested").type == "JSON"
+    row = db_json["t2"].get(1)
+    assert isinstance(row["nested"], dict)
+    assert row["nested"] == {"foo": "bar"}
+
+def test_query_json_converters(tmpdir):
+    db_path = str(tmpdir / "test.db")
+    db = Database(db_path, use_json_converters=True)
+    db["t"].insert({"id": 1, "data": {"a": 1}}, pk="id")
+    
+    runner = CliRunner()
+    
+    # Query without flag - ensure it does not automatically deserialize by default in CLI
+    result = runner.invoke(cli.cli, ["query", db_path, "select * from t"])
+    assert result.exit_code == 0
+    assert '"data": "{\\"a\\": 1}"' in result.output
+    
+    # Query WITH flag
+    result = runner.invoke(cli.cli, ["query", db_path, "select * from t", "--use-json-converters"])
+    assert result.exit_code == 0
+    # Now it should be a real nested object in the JSON output
+    assert '"data": {"a": 1}' in result.output
+
+def test_create_table_json_type(tmpdir):
+    db_path = str(tmpdir / "test.db")
+    runner = CliRunner()
+    
+    # Create table with JSON type
+    result = runner.invoke(cli.cli, ["create-table", db_path, "t", "id", "integer", "data", "json", "--pk", "id"])
+    assert result.exit_code == 0
+    
+    db = Database(db_path)
+    assert next(c for c in db["t"].columns if c.name == "data").type == "JSON"
+
+def test_memory_json_converters(tmpdir):
+    csv_path = str(tmpdir / "test.csv")
+    with open(csv_path, "w") as f:
+        f.write("id,data\n1,'{\"a\": 1}'")
+        
+    runner = CliRunner()
+    
+    # Query memory with flag - check output deserialization
+    result = runner.invoke(cli.cli, ["memory", csv_path, "select * from test", "--use-json-converters"])
+    assert result.exit_code == 0
+    
+    # Let's try with JSON input
+    json_path = str(tmpdir / "test.json")
+    with open(json_path, "w") as f:
+        json.dump([{"id": 1, "data": {"a": 1}}], f)
+        
+    result = runner.invoke(cli.cli, ["memory", json_path, "select * from test", "--use-json-converters"])
+    assert result.exit_code == 0
+    assert '"data": {"a": 1}' in result.output

--- a/tests/test_issue_612.py
+++ b/tests/test_issue_612.py
@@ -1,0 +1,184 @@
+import pytest
+import json
+from sqlite_utils import Database
+
+def test_insert_dict_default_behavior():
+    """
+    By default (without use_json_converters=True), inserting a dict
+    should create a TEXT column and return a string.
+    """
+    db = Database(memory=True)
+    data = {"id": 1, "nested": {"foo": "bar"}}
+    t = db["t"]
+    t.insert(data, pk="id")
+    
+    # Check column type
+    # Access column by name to be robust against ordering changes
+    col = next(c for c in t.columns if c.name == "nested")
+    assert col.type == "TEXT"
+    
+    # Check returned value
+    row = t.get(1)
+    assert isinstance(row["nested"], str)
+    assert row["nested"] == '{"foo": "bar"}'
+
+def test_explicit_json_column_creation():
+    """
+    Test repeatedly creating a table with a specific JSON column type.
+    """
+    db = Database(memory=True)
+    # This should work if JSON is in COLUMN_TYPE_MAPPING
+    db["t"].create({"id": int, "data": "JSON"}, pk="id")
+    col = next(c for c in db["t"].columns if c.name == "data")
+    assert col.type == "JSON"
+
+def test_use_json_converters_argument_exists():
+    """
+    Test that Database accepts use_json_converters argument.
+    """
+    # strict=False is default, just ensuring we can pass the arg
+    try:
+        db = Database(memory=True, use_json_converters=True)
+    except TypeError:
+        pytest.fail("Database does not accept use_json_converters argument")
+
+def test_insert_dict_with_json_converters_enabled():
+    """
+    With use_json_converters=True:
+    1. Inserting a dict should create a JSON column.
+    2. Retrieving it should return a dict (auto-deserialization).
+    """
+    db = Database(memory=True, use_json_converters=True)
+    data = {"id": 1, "attrs": {"color": "red", "size": 10}}
+    
+    db["items"].insert(data, pk="id")
+    
+    # Verify column type is inferred as JSON (not JSONB)
+    col = next(c for c in db["items"].columns if c.name == "attrs")
+    assert col.type == "JSON"
+    
+    # Verify auto-deserialization
+    row = db["items"].get(1)
+    assert isinstance(row["attrs"], dict)
+    assert row["attrs"] == data["attrs"]
+    
+def test_list_deserialization():
+    """
+    Test that lists are also handled correctly when use_json_converters=True.
+    """
+    db = Database(memory=True, use_json_converters=True)
+
+    data = {"id": 1, "tags": ["a", "b", "c"]}
+    db["items"].insert(data, pk="id")
+    
+    # Verify column type is inferred as JSON
+    col = next(c for c in db["items"].columns if c.name == "tags")
+    assert col.type == "JSON"
+
+    # Verify deserialization
+    row = db["items"].get(1)
+    assert isinstance(row["tags"], list)
+    assert row["tags"] == ["a", "b", "c"]
+
+def test_explicit_json_column_deserialization():
+    """
+    Test that explicit JSON columns are deserialized when flag is enabled.
+    """
+    db = Database(memory=True, use_json_converters=True)
+    
+    # Create table explicitly
+    db["t"].create({"id": int, "data": "JSON"}, pk="id")
+    
+    data = {"foo": "bar"}
+    db["t"].insert({"id": 1, "data": data})
+    
+    # Explicit creation doesn't rely on suggest_column_types for type, but insert might
+    row = db["t"].get(1)
+    assert isinstance(row["data"], dict)
+    assert row["data"] == data
+
+def test_suggest_column_types_conditional_behavior():
+    """
+    Test that suggest_column_types behaves differently when json_converters=True.
+    """
+    from sqlite_utils.utils import suggest_column_types
+    records = [{"a": {"foo": "bar"}}, {"a": {"baz": 1}}]
+    
+    # Default: returns str
+    assert suggest_column_types(records) == {"a": str}
+    assert suggest_column_types(records, json_converters=False) == {"a": str}
+    
+    # With flag: returns dict
+    assert suggest_column_types(records, json_converters=True) == {"a": dict}
+    
+    list_records = [{"b": [1, 2]}, {"b": [3]}]
+    assert suggest_column_types(list_records, json_converters=True) == {"b": list}
+
+def test_json_null_values():
+    """
+    Test that null values are handled correctly in JSON columns.
+    """
+    db = Database(memory=True, use_json_converters=True)
+    db["t"].insert({"id": 1, "data": None}, pk="id")
+    
+    # Check column type (should be inferred as TEXT by default if only None is seen, 
+    # but here we just want to see if it breaks)
+    row = db["t"].get(1)
+    assert row["data"] is None
+
+def test_deeply_nested_structures():
+    """
+    Test deeply nested structures.
+    """
+    db = Database(memory=True, use_json_converters=True)
+    data = {"a": {"b": {"c": [1, 2, {"d": "e"}]}}}
+    db["t"].insert({"id": 1, "data": data}, pk="id")
+    
+    row = db["t"].get(1)
+    assert row["data"] == data
+
+def test_malformed_json_raises_error():
+    """
+    Test that malformed JSON in a JSON-declared column raises an error on retrieval.
+    This is standard SQLite PARSE_DECLTYPES behavior with a registered converter.
+    """
+    import sqlite3
+    db = Database(memory=True, use_json_converters=True)
+    # Manually insert malformed JSON into a JSON column
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, data JSON)")
+    db.execute("INSERT INTO t (id, data) VALUES (1, '{malformed')")
+    
+    with pytest.raises(Exception):
+        db["t"].get(1)
+
+def test_json_converters_only_affects_json_columns():
+    """
+    Verfiy that use_json_converters=True does NOT affect columns declared as TEXT.
+    """
+    db = Database(memory=True, use_json_converters=True)
+    db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)")
+    db.execute("INSERT INTO t (id, data) VALUES (1, '{\"a\": 1}')")
+    
+    row = db["t"].get(1)
+    assert isinstance(row["data"], str)
+    assert row["data"] == '{"a": 1}'
+
+def test_tuple_deserialization():
+    """
+    Test that tuples are also handled correctly when use_json_converters=True.
+    """
+    db = Database(memory=True, use_json_converters=True)
+
+    data = {"id": 1, "nested_tuple": (1, 2, 3)}
+    db["items"].insert(data, pk="id")
+    
+    # Verify column type is inferred as JSON
+    col = next(c for c in db["items"].columns if c.name == "nested_tuple")
+    assert col.type == "JSON"
+
+    # Verify deserialization
+    row = db["items"].get(1)
+    # Tuples become lists after JSON roundtrip
+    assert isinstance(row["nested_tuple"], list)
+    assert row["nested_tuple"] == [1, 2, 3]
+


### PR DESCRIPTION
# Add automatic JSON deserialization support

This PR implements automatic JSON deserialization for columns declared with the `JSON` type, as requested in #612. It introduces a new `use_json_converters=True` option that allows the library to automatically handle nested Python structures (dictionaries, lists, and tuples) by storing them in `JSON` columns and deserializing them back into native Python objects upon retrieval.

### Key Changes

- **[Database](cci:2://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/db.py:304:0-1380:41) Constructor**: Added a `use_json_converters: bool = False` argument. When enabled:
    - Registers a custom SQLite converter for the `JSON` type using `json.loads`.
    - Enables `sqlite3.PARSE_DECLTYPES` on the connection.
    - Updates `COLUMN_TYPE_MAPPING` to include `"JSON": "JSON"`.
- **Type Inference**: Modified [suggest_column_types](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/tests/test_issue_612.py:105:0-121:82) (and `types_for_column_types`) to accept a [json_converters](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/tests/test_cli_json_converters.py:39:0-57:46) parameter. If `True`, nested structures are inferred as [dict](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/db.py:1512:4-1515:85) or [list](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/cli.py:3297:0-3300:51) (mapping to `JSON`) rather than [str](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/db.py:1754:4-1759:40).
- **CLI Commands**: Added a `--use-json-converters` flag to the following commands:
    - [query](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/cli.py:1826:0-1912:5)
    - [memory](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/cli.py:1915:0-2132:5)
    - [insert](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/cli.py:1211:0-1345:60)
    - [upsert](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/cli.py:1348:0-1430:60)
    - [bulk](cci:1://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/cli.py:1433:0-1526:42)
- **`create-table` Support**: The `create-table` CLI command and `Table.create()` API now explicitly support `"JSON"` (case-insensitive) as a valid column type.

### Validation

- **New Tests**:
    - Added [tests/test_issue_612.py](cci:7://file:///mnt/hdd2/Mars/Projects/sqlite-utils/tests/test_issue_612.py:0:0-0:0) to test the Python API behavior, including round-trip serialization/deserialization, type inference, and edge cases (null values, malformed JSON).
    - Added [tests/test_cli_json_converters.py](cci:7://file:///mnt/hdd2/Mars/Projects/sqlite-utils/tests/test_cli_json_converters.py:0:0-0:0) to verify the new CLI flags and `JSON` type support.
- **Regression Testing**: Ran the full test suite (1,072 tests), and all passed.
- **Linting & Types**: Verified that the codebase passes `black`, `flake8`, and `mypy` checks.

### Documentation

- Updated [docs/python-api.rst](cci:7://file:///mnt/hdd2/Mars/Projects/sqlite-utils/docs/python-api.rst:0:0-0:0) to document the new [Database](cci:2://file:///mnt/hdd2/Mars/Projects/sqlite-utils/sqlite_utils/db.py:304:0-1380:41) argument.
- Updated [docs/cli.rst](cci:7://file:///mnt/hdd2/Mars/Projects/sqlite-utils/docs/cli.rst:0:0-0:0) to document the new `--use-json-converters` flag and the `JSON` type for `create-table`.
- Added a changelog entry for the upcoming `3.40` release in `docs/changelog.rst`.

Closes #612

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--698.org.readthedocs.build/en/698/

<!-- readthedocs-preview sqlite-utils end -->