### PR TITLE
docs: fix typo 'Yo ucan' -> 'You can' in cli.rst

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2030,7 +2030,7 @@ You can also pass ``--transform`` to transform the existing table to match the n
 Renaming a table
 ================
 
-Yo ucan rename a table using the ``rename-table`` command:
+You can rename a table using the ``rename-table`` command:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Simple typo fix in the 'Renaming a table' section of the CLI documentation.

**Before:** `Yo ucan rename a table using the rename-table command:`
**After:** `You can rename a table using the rename-table command:`

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--701.org.readthedocs.build/en/701/

<!-- readthedocs-preview sqlite-utils end -->