### PR TITLE
Fix: CSV insert with --detect-types crashes on header-only CSV

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1176,7 +1176,7 @@ def insert_upsert_implementation(
                 )
             else:
                 raise
-        if tracker is not None:
+        if tracker is not None and db[table].exists():
             db.table(table).transform(types=tracker.types)
 
         # Clean up open file-like objects


### PR DESCRIPTION
When using --detect-types with a CSV file containing only a header row (and no data rows), the insert would fail with 'Cannot transform a table that doesn't exist yet' because the table is only created when rows are inserted. This fix adds an existence check before attempting to transform.

Fixes #702

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--706.org.readthedocs.build/en/706/

<!-- readthedocs-preview sqlite-utils end -->