### PR TITLE
Fix: Handle CSV with only header row in --detect-types (fixes #702)

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1176,7 +1176,7 @@ def insert_upsert_implementation(
                 )
             else:
                 raise
-        if tracker is not None:
+        if tracker is not None and db.table(table).exists():
             db.table(table).transform(types=tracker.types)
 
         # Clean up open file-like objects
@@ -2033,7 +2033,7 @@ def memory(
                 rows = (_flatten(row) for row in rows)
 
             db.table(file_table).insert_all(rows, alter=True)
-            if tracker is not None:
+            if tracker is not None and db.table(file_table).exists():
                 db.table(file_table).transform(types=tracker.types)
             # Add convenient t / t1 / t2 views
             view_names = ["t{}".format(i + 1)]

--- a/tests/test_cli_insert.py
+++ b/tests/test_cli_insert.py
@@ -597,3 +597,21 @@ def test_insert_streaming_batch_size_1(db_path):
     proc.stdin.close()
     proc.wait()
     assert proc.returncode == 0
+
+
+def test_insert_csv_headers_only(tmpdir):
+    """Test that CSV with only header row (no data) works with --detect-types (issue #702)"""
+    db_path = str(tmpdir / "test.db")
+    csv_path = str(tmpdir / "headers_only.csv")
+    with open(csv_path, "w") as fp:
+        fp.write("id,name,age\n")
+    # Should not crash with --detect-types (which is now the default)
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "data", csv_path, "--csv"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    # Table should not exist since there were no data rows
+    db = Database(db_path)
+    assert not db["data"].exists()


### PR DESCRIPTION
This PR fixes issue #702 where inserting a CSV file with only a header row (no data rows) would crash when using --detect-types.

## Problem
When a CSV contains only headers and no data rows:
1. The TypeTracker wraps the docs iterator but no rows are tracked
2. After insert_all, the table doesn't exist (no rows were inserted)
3. Calling transform(types=tracker.types) fails because the table doesn't exist

## Solution
Added a check to ensure the table exists before attempting to apply type transformations:
- Changed `if tracker is not None:` to `if tracker is not None and db.table(table).exists():`
- Applied in both `insert_upsert_implementation()` and `memory()` commands

## Changes
- Modified `sqlite_utils/cli.py`: Added existence check before transform
- Added test `test_insert_csv_headers_only` to verify the fix

## Testing
- Added new test case that verifies CSV with only headers doesn't crash
- Verified the fix resolves the exact error from issue #702

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--707.org.readthedocs.build/en/707/

<!-- readthedocs-preview sqlite-utils end -->