### PR TITLE
Fix: CSV insert with --detect-types crashes on header-only CSV

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1176,7 +1176,7 @@ def insert_upsert_implementation(
                 )
             else:
                 raise
-        if tracker is not None:
+        if tracker is not None and db.table(table).exists():
             db.table(table).transform(types=tracker.types)
 
         # Clean up open file-like objects
@@ -2033,7 +2033,7 @@ def memory(
                 rows = (_flatten(row) for row in rows)
 
             db.table(file_table).insert_all(rows, alter=True)
-            if tracker is not None:
+            if tracker is not None and db.table(file_table).exists():
                 db.table(file_table).transform(types=tracker.types)
             # Add convenient t / t1 / t2 views
             view_names = ["t{}".format(i + 1)]

--- a/tests/test_cli_insert.py
+++ b/tests/test_cli_insert.py
@@ -597,3 +597,19 @@ def test_insert_streaming_batch_size_1(db_path):
     proc.stdin.close()
     proc.wait()
     assert proc.returncode == 0
+
+
+def test_insert_csv_header_only(tmpdir):
+    # https://github.com/simonw/sqlite-utils/issues/702
+    # Inserting a CSV with only a header row (no data) and --detect-types
+    # should not crash
+    db_path = str(tmpdir / "test.db")
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "data", "-", "--csv", "--detect-types"],
+        input="foo,bar,baz",
+    )
+    assert result.exit_code == 0, result.output
+    # Table should not exist since no rows were inserted
+    db = Database(db_path)
+    assert "data" not in db.table_names()


### PR DESCRIPTION
## Problem
When using `sqlite-utils insert` with `--detect-types` flag on a CSV file containing only a header row (no data), the command crashes with:
```
AssertionError: Cannot transform a table that doesn't exist yet
```

## Root Cause
The `transform()` method was being called to apply detected types to the table, but when there are no data rows, the table is never created.

## Fix
Added existence checks before calling `transform()` in two locations in `cli.py`.

## Testing
Added `test_insert_csv_header_only()` to verify the fix.

Fixes #702

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--710.org.readthedocs.build/en/710/

<!-- readthedocs-preview sqlite-utils end -->