### PR TITLE
docs: clarify that insert()/insert_all() commit in batches

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -528,6 +528,12 @@ You can also specify a primary key by passing the ``pk=`` parameter to the ``.in
 
 After inserting a row like this, the ``dogs.last_rowid`` property will return the SQLite ``rowid`` assigned to the most recently inserted record.
 
+.. note::
+
+    ``.insert()`` and ``.insert_all()`` commit writes in batches (``.insert()`` writes one-row batches).
+    If you are manually controlling transactions using a SQLite connection context manager, calling these methods
+    may commit earlier than expected.
+
 The ``dogs.last_pk`` property will return the last inserted primary key value, if you specified one. This can be very useful when writing code that creates foreign keys or many-to-many relationships.
 
 .. _python_api_custom_columns:


### PR DESCRIPTION
## Summary
- add a note to the Python API docs for .insert() / .insert_all()
- clarify that writes are committed in batches and may commit earlier than expected in manually-managed transactions

## Testing
- Not run locally (pytest is not installed in this environment).

Fixes #712