### PR TITLE
Avoid loading setuptools plugins under pytest

### DIFF
--- a/sqlite_utils/plugins.py
+++ b/sqlite_utils/plugins.py
@@ -7,8 +7,15 @@ from . import hookspecs
 pm: pluggy.PluginManager = pluggy.PluginManager("sqlite_utils")
 pm.add_hookspecs(hookspecs)
 
-if not getattr(sys, "_called_from_test", False):
-    # Only load plugins if not running tests
+
+def _should_load_setuptools_plugins() -> bool:
+    # Avoid loading setuptools plugins while running test suites.
+    # Checking sys.modules for pytest makes this robust even if
+    # sys._called_from_test is set later during test initialization.
+    return not getattr(sys, "_called_from_test", False) and "pytest" not in sys.modules
+
+
+if _should_load_setuptools_plugins():
     pm.load_setuptools_entrypoints("sqlite_utils")
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,6 +2,7 @@ from click.testing import CliRunner
 import click
 import importlib
 import pytest
+import sys
 from sqlite_utils import cli, Database, hookimpl, plugins
 
 
@@ -14,6 +15,12 @@ def _supports_pragma_function_list():
         return False
     finally:
         db.close()
+
+
+def test_should_not_load_setuptools_plugins_when_pytest_present(monkeypatch):
+    monkeypatch.delattr(sys, "_called_from_test", raising=False)
+    assert plugins._should_load_setuptools_plugins() is False
+
 
 
 def test_register_commands():


### PR DESCRIPTION
## Summary
Fixes plugin auto-loading during tests when `sys._called_from_test` has not yet been set.

## What changed
- Added `_should_load_setuptools_plugins()` in `sqlite_utils/plugins.py`
- Updated plugin auto-load guard to also check if `pytest` is present in `sys.modules`
- Added regression test for that guard in `tests/test_plugins.py`

## Testing
- `uv run pytest tests/test_plugins.py -q`

Fixes #713


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--715.org.readthedocs.build/en/715/

<!-- readthedocs-preview sqlite-utils end -->