### PR TITLE
fix: Insert CSV with --detect-types crashes for CSV files that contain only a header row

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1176,7 +1176,7 @@ def insert_upsert_implementation(
                 )
             else:
                 raise
-        if tracker is not None:
+        if tracker is not None and db.table(table).exists():
             db.table(table).transform(types=tracker.types)
 
         # Clean up open file-like objects

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2305,6 +2305,21 @@ def test_insert_detect_types(tmpdir, option):
     ]
 
 
+def test_insert_detect_types_header_only_csv(tmpdir):
+    db_path = str(tmpdir / "test.db")
+    data = "name,age\n"
+
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "creatures", "-", "--csv", "--detect-types"],
+        catch_exceptions=False,
+        input=data,
+    )
+    assert result.exit_code == 0
+    db = Database(db_path)
+    assert not db["creatures"].exists()
+
+
 @pytest.mark.parametrize("option", (None, "-d", "--detect-types"))
 def test_upsert_detect_types(tmpdir, option):
     """Test that type detection is now the default behavior for upsert"""


### PR DESCRIPTION
## Summary
Fixes a crash in `sqlite-utils insert` when importing a CSV that only contains a header row with `--detect-types`. The command should succeed without attempting to transform a table that was never created.

## Changes
- Added a guard in the CLI insert flow to only run `transform(types=...)` when the table actually exists
- Added a regression test covering `insert --csv --detect-types` with header-only CSV input

## Testing
- Ran: `.venv/bin/pytest -q tests/test_cli.py -k "detect_types and (insert or upsert)"`
- Result: `9 passed`

Fixes simonw/sqlite-utils#702

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--716.org.readthedocs.build/en/716/

<!-- readthedocs-preview sqlite-utils end -->