### PR TITLE
Clarify ensure_autocommit_off() autocommit behavior

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -403,14 +403,18 @@ class Database:
     @contextlib.contextmanager
     def ensure_autocommit_off(self) -> Generator[None, None, None]:
         """
-        Ensure autocommit is off for this database connection.
+        Ensure autocommit is on for this database connection.
+
+        Despite the historical method name, this temporarily sets
+        ``self.conn.isolation_level = None`` so statements execute in autocommit
+        mode inside the block.
 
         Example usage::
 
             with db.ensure_autocommit_off():
                 # do stuff here
 
-        This will reset to the previous autocommit state at the end of the block.
+        This will reset to the previous isolation level at the end of the block.
         """
         old_isolation_level = self.conn.isolation_level
         try:

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -21,3 +21,11 @@ def test_enable_disable_wal(db_path_tmpdir):
     db.disable_wal()
     assert "delete" == db.journal_mode
     assert "test.db-wal" not in [f.basename for f in tmpdir.listdir()]
+
+
+def test_ensure_autocommit_off_sets_autocommit_mode_temporarily(db_path_tmpdir):
+    db, path, tmpdir = db_path_tmpdir
+    original_isolation_level = db.conn.isolation_level
+    with db.ensure_autocommit_off():
+        assert db.conn.isolation_level is None
+    assert db.conn.isolation_level == original_isolation_level


### PR DESCRIPTION
Fixes #705

`ensure_autocommit_off()` was behaving correctly for WAL pragmas, but its docstring said the opposite.

## What changed
- Updated the `ensure_autocommit_off()` docstring to explicitly describe that it temporarily sets `isolation_level = None`, i.e. autocommit mode.
- Added a regression test asserting that the context manager sets `isolation_level` to `None` inside the block and restores the prior value afterward.

## Testing
- `python3 -m compileall -q sqlite_utils/db.py tests/test_wal.py`
- Could not run `pytest` in this environment because `pytest` is not installed.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--717.org.readthedocs.build/en/717/

<!-- readthedocs-preview sqlite-utils end -->