### PR TITLE
fix: Table.insert() documentation does not make it clear it will commit

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -3382,6 +3382,8 @@ class Table(Queryable):
         Insert a single record into the table. The table will be created with a schema that matches
         the inserted record if it does not already exist, see :ref:`python_api_creating_tables`.
 
+        This method commits its changes as part of an internal transaction.
+
         - ``record`` - required: a dictionary representing the record to be inserted.
 
         The other parameters are optional, and mostly influence how the new table will be created if


### PR DESCRIPTION
## Summary
Clarifies the `Table.insert()` reference documentation to explicitly state that it commits changes as part of an internal transaction.

## Changes
- Updated the `Table.insert()` docstring in `sqlite_utils/db.py` with a sentence describing commit behavior.

## Testing
- `python3 -m compileall -q sqlite_utils/db.py`
- Could not run `pytest` in this environment (`No module named pytest`).

Closes #712

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--718.org.readthedocs.build/en/718/

<!-- readthedocs-preview sqlite-utils end -->