### PR TITLE
fix: Plugins are still loaded when running tests

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -14,7 +14,7 @@ from sqlite_utils.db import (
     NoTable,
     quote_identifier,
 )
-from sqlite_utils.plugins import pm, get_plugins
+from sqlite_utils.plugins import ensure_plugins_loaded, pm, get_plugins
 from sqlite_utils.utils import maximize_csv_field_size_limit
 from sqlite_utils import recipes
 import textwrap
@@ -3264,6 +3264,7 @@ def plugins_list():
     click.echo(json.dumps(get_plugins(), indent=2))
 
 
+ensure_plugins_loaded()
 pm.hook.register_commands(cli=cli)
 
 

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -40,7 +40,7 @@ from typing import (
     Tuple,
 )
 import uuid
-from sqlite_utils.plugins import pm
+from sqlite_utils.plugins import ensure_plugins_loaded, pm
 
 try:
     from sqlite_dump import iterdump  # type: ignore[import-not-found]
@@ -382,6 +382,7 @@ class Database:
         self._registered_functions: set = set()
         self.use_counts_table = use_counts_table
         if execute_plugins:
+            ensure_plugins_loaded()
             pm.hook.prepare_connection(conn=self.conn)
         self.strict = strict
 

--- a/sqlite_utils/plugins.py
+++ b/sqlite_utils/plugins.py
@@ -18,6 +18,7 @@ def ensure_plugins_loaded() -> None:
 
 
 def get_plugins() -> List[Dict[str, Union[str, List[str]]]]:
+    ensure_plugins_loaded()
     plugins: List[Dict[str, Union[str, List[str]]]] = []
     plugin_to_distinfo = dict(pm.list_plugin_distinfo())
     for plugin in pm.get_plugins():

--- a/sqlite_utils/plugins.py
+++ b/sqlite_utils/plugins.py
@@ -6,10 +6,15 @@ from . import hookspecs
 
 pm: pluggy.PluginManager = pluggy.PluginManager("sqlite_utils")
 pm.add_hookspecs(hookspecs)
+_plugins_loaded = False
 
-if not getattr(sys, "_called_from_test", False):
-    # Only load plugins if not running tests
+
+def ensure_plugins_loaded() -> None:
+    global _plugins_loaded
+    if _plugins_loaded or getattr(sys, "_called_from_test", False):
+        return
     pm.load_setuptools_entrypoints("sqlite_utils")
+    _plugins_loaded = True
 
 
 def get_plugins() -> List[Dict[str, Union[str, List[str]]]]:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,6 +2,7 @@ from click.testing import CliRunner
 import click
 import importlib
 import pytest
+import sys
 from sqlite_utils import cli, Database, hookimpl, plugins
 
 
@@ -14,6 +15,36 @@ def _supports_pragma_function_list():
         return False
     finally:
         db.close()
+
+
+def test_get_plugins_loads_setuptools_entrypoints_once(monkeypatch):
+    calls = []
+    monkeypatch.delattr(sys, "_called_from_test", raising=False)
+    monkeypatch.setattr(plugins, "_plugins_loaded", False)
+    monkeypatch.setattr(
+        plugins.pm,
+        "load_setuptools_entrypoints",
+        lambda group: calls.append(group) or 0,
+    )
+
+    plugins.get_plugins()
+    plugins.get_plugins()
+
+    assert calls == ["sqlite_utils"]
+
+
+def test_get_plugins_does_not_load_setuptools_entrypoints_in_tests(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sys, "_called_from_test", True, raising=False)
+    monkeypatch.setattr(plugins, "_plugins_loaded", False)
+    monkeypatch.setattr(
+        plugins.pm,
+        "load_setuptools_entrypoints",
+        lambda group: calls.append(group) or 0,
+    )
+
+    assert plugins.get_plugins() == []
+    assert calls == []
 
 
 def test_register_commands():


### PR DESCRIPTION
## Summary

Plugin entrypoints were being loaded at module import time, before tests set `sys._called_from_test`, which allowed system-installed plugins to leak into test runs. This change defers entrypoint loading until plugin hooks are actually used, and only when not running tests.

## Changes

- Added `ensure_plugins_loaded()` and a one-time `_plugins_loaded` guard in `sqlite_utils/plugins.py`
- Updated `Database.__init__()` to call `ensure_plugins_loaded()` before `prepare_connection` hooks
- Updated `cli.py` to call `ensure_plugins_loaded()` before `register_commands` hooks

## Testing

- Created a virtualenv and ran: `pytest -q tests/test_plugins.py`
- Result: `2 passed`

Fixes simonw/sqlite-utils#713

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--719.org.readthedocs.build/en/719/

<!-- readthedocs-preview sqlite-utils end -->