### PR TITLE
Improve typing for db["table"] usage

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -445,7 +445,7 @@ class Database:
         finally:
             self._tracer = prev_tracer
 
-    def __getitem__(self, table_name: str) -> Union["Table", "View"]:
+    def __getitem__(self, table_name: str) -> "Table":
         """
         ``db[table_name]`` returns a :class:`.Table` object for the table with the specified name.
         If the table does not exist yet it will be created the first time data is inserted into it.
@@ -453,7 +453,7 @@ class Database:
         :param table_name: The name of the table
         """
         if table_name in self.view_names():
-            return self.view(table_name)
+            return cast("Table", self.view(table_name))
         return self.table(table_name)
 
     def __repr__(self) -> str:

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,13 @@
+import typing
+
+from sqlite_utils.db import Database, Table, View
+
+
+def test_database_getitem_return_type_hint_is_table():
+    assert typing.get_type_hints(Database.__getitem__)["return"] is Table
+
+
+def test_database_getitem_still_returns_view_for_views(fresh_db):
+    fresh_db["items"].insert({"name": "one"})
+    fresh_db.create_view("items_view", "select * from items")
+    assert isinstance(fresh_db["items_view"], View)


### PR DESCRIPTION
## Summary
- annotate `Database.__getitem__` as returning `Table` for static type checkers
- keep existing runtime behavior for views by casting the view return path
- add typing-focused regression tests for the return annotation and view runtime behavior

## Why
Fixes #638, where mypy/pyright report errors for common `db["name"].create(...)` and `upsert(...)` usage.

## Validation
- `uv run flake8 sqlite_utils/db.py tests/test_typing.py`
- `uv run mypy sqlite_utils tests`
- `uv run pytest tests/test_typing.py -q`
- `uv run pytest tests/test_create.py -k view -q`