### PR TITLE
docs: fix rendered dashes for install command options

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -257,6 +257,7 @@ Available ``--fmt`` options are:
 .. ]]]
 
 - ``asciidoc``
+- ``colon_grid``
 - ``double_grid``
 - ``double_outline``
 - ``fancy_grid``
@@ -2786,7 +2787,7 @@ See this `SpatiaLite Cookbook recipe <http://www.gaia-gis.it/gaia-sins/spatialit
 Installing packages
 ===================
 
-The :ref:`convert command <cli_convert>` and the :ref:`insert -\\-convert <cli_insert_convert>` and :ref:`query -\\-functions <cli_query_functions>` options can be provided with a Python script that imports additional modules from the ``sqlite-utils`` environment.
+The :ref:`convert command <cli_convert>` and the ``insert --convert`` (:ref:`cli_insert_convert`) and ``query --functions`` (:ref:`cli_query_functions`) options can be provided with a Python script that imports additional modules from the ``sqlite-utils`` environment.
 
 You can install packages from PyPI directly into the correct environment using ``sqlite-utils install <package>``. This is a wrapper around ``pip install``.
 


### PR DESCRIPTION
## Summary
Fixes the rendered typo in the install/uninstall docs where command-line options appeared with an en dash (`–`) instead of two hyphens.

## Changes
- Reworded the sentence to use literal code spans: `insert --convert` and `query --functions`
- Kept both options linked to their existing docs references

## Testing
- `uv run --group docs cog -r docs/cli.rst`
- `uv run --group docs cog --check docs/cli.rst`
- `uv run --group docs codespell docs/cli.rst --ignore-words docs/codespell-ignore-words.txt`
- `uv run pytest tests/test_cli.py -q` (182 passed, 3 skipped)

Fixes simonw/sqlite-utils#493

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--723.org.readthedocs.build/en/723/

<!-- readthedocs-preview sqlite-utils end -->