### PR TITLE
test: enforce warnings-as-errors in pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ sqlite-utils = "sqlite_utils.cli:cli"
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+filterwarnings = ["error"]
+
 [tool.flake8]
 max-line-length = 160
 # Black compatibility, E203 whitespace before ':':


### PR DESCRIPTION
## Summary

Closes #541.

All 1040 tests already pass with `pytest -W error` (Python 3.13, with `hypothesis` installed). This PR codifies that constraint in `pyproject.toml` so the guarantee is automatically enforced on every future run — no need to remember the manual flag.

```toml
[tool.pytest.ini_options]
filterwarnings = ["error"]
```

## Test plan

- [x] `pytest tests/` — 1040 passed, 16 skipped, 0 errors (with `filterwarnings = ["error"]` active)
- [x] Verified the `test_hypothesis.py` file also passes (requires `hypothesis` to be installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--725.org.readthedocs.build/en/725/

<!-- readthedocs-preview sqlite-utils end -->