### PR TITLE
docs: add docstrings to four undocumented public methods

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -638,6 +638,16 @@ class Database:
         )
 
     def quote_default_value(self, value: str) -> str:
+        """
+        Return a SQL-safe representation of a column default value.
+
+        Already-quoted string literals and the SQLite special keywords
+        ``CURRENT_TIME``, ``CURRENT_DATE``, and ``CURRENT_TIMESTAMP`` are
+        returned unchanged.  Expressions that end in ``)`` are wrapped in
+        parentheses.  All other values are passed through :meth:`quote`.
+
+        :param value: The default value to format.
+        """
         if any(
             [
                 str(value).startswith("'") and str(value).endswith("'"),
@@ -735,6 +745,12 @@ class Database:
 
     @property
     def supports_on_conflict(self) -> bool:
+        """
+        Return ``True`` if the connected SQLite version supports upserts via
+        ``INSERT INTO ... ON CONFLICT DO UPDATE`` (requires SQLite 3.24+).
+
+        The result is cached on the instance after the first call.
+        """
         # SQLite's upsert is implemented as INSERT INTO ... ON CONFLICT DO ...
         if not hasattr(self, "_supports_on_conflict"):
             table_name = "t{}".format(secrets.token_hex(16))
@@ -839,6 +855,12 @@ class Database:
     def execute_returning_dicts(
         self, sql: str, params: Optional[Union[Sequence, Dict[str, Any]]] = None
     ) -> List[dict]:
+        """
+        Execute a SQL query and return the results as a list of dictionaries.
+
+        :param sql: SQL query to execute.
+        :param params: Optional parameters to pass to the query.
+        """
         return list(self.query(sql, params))
 
     def resolve_foreign_keys(
@@ -1396,6 +1418,13 @@ class Queryable:
         return self.db.execute(sql, where_args or []).fetchone()[0]
 
     def execute_count(self) -> int:
+        """
+        Return the total number of rows in this table or view.
+
+        .. deprecated::
+            Use :meth:`count_where` or the :attr:`count` property instead.
+            Kept for backwards compatibility only.
+        """
         # Backwards compatibility, see https://github.com/simonw/sqlite-utils/issues/305#issuecomment-890713185
         return self.count_where()
 


### PR DESCRIPTION
## Summary

Four public methods in `sqlite_utils/db.py` lacked docstrings entirely,
making their behaviour unclear from the source.  This PR adds concise
docstrings matching the existing `:param name:` style used throughout the file.

## Changes

- `Database.quote_default_value`: documents pass-through behaviour for
  already-quoted literals, SQLite date/time keywords, and expressions
- `Database.supports_on_conflict`: documents the SQLite 3.24+ requirement
  and the caching behaviour
- `Database.execute_returning_dicts`: documents the SQL/params parameters
- `Queryable.execute_count`: marks it as deprecated in favour of
  `count_where()` / the `count` property, linking to the relevant issue

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--726.org.readthedocs.build/en/726/

<!-- readthedocs-preview sqlite-utils end -->