### PR TITLE
fix(cli): honor --no-headers flag with --fmt/--table output

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -237,7 +237,13 @@ def tables(
             yield row
 
     if table or fmt:
-        print(tabulate.tabulate(_iter(), headers=headers, tablefmt=fmt or "simple"))
+        print(
+            tabulate.tabulate(
+                _iter(),
+                headers=() if no_headers else headers,
+                tablefmt=fmt or "simple",
+            )
+        )
     elif csv or tsv:
         writer = csv_std.writer(sys.stdout, dialect="excel-tab" if tsv else "excel")
         if not no_headers:
@@ -2139,7 +2145,9 @@ def _execute_query(
         elif fmt or table:
             print(
                 tabulate.tabulate(
-                    list(cursor), headers=headers, tablefmt=fmt or "simple"
+                    list(cursor),
+                    headers=() if no_headers else headers,
+                    tablefmt=fmt or "simple",
                 )
             )
         elif csv or tsv:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,6 +195,56 @@ def test_output_table(db_path, options, expected):
     assert expected == result.output.strip()
 
 
+@pytest.mark.parametrize(
+    "fmt,expected",
+    [
+        (
+            "plain",
+            "verb0  noun0  adjective0\nverb1  noun1  adjective1\nverb2  noun2  adjective2\nverb3  noun3  adjective3",
+        ),
+        (
+            "simple",
+            "-----  -----  ----------\nverb0  noun0  adjective0\nverb1  noun1  adjective1\nverb2  noun2  adjective2\nverb3  noun3  adjective3\n-----  -----  ----------",
+        ),
+    ],
+)
+def test_output_table_no_headers(db_path, fmt, expected):
+    db = Database(db_path)
+    with db.conn:
+        db["rows"].insert_all(
+            [
+                {
+                    "c1": "verb{}".format(i),
+                    "c2": "noun{}".format(i),
+                    "c3": "adjective{}".format(i),
+                }
+                for i in range(4)
+            ]
+        )
+    result = CliRunner().invoke(
+        cli.cli, ["rows", db_path, "rows", "--fmt", fmt, "--no-headers"]
+    )
+    assert result.exit_code == 0
+    assert expected == result.output.strip()
+
+
+def test_query_fmt_no_headers(db_path):
+    db = Database(db_path)
+    with db.conn:
+        db["dogs"].insert_all(
+            [
+                {"id": 1, "name": "Cleo"},
+                {"id": 2, "name": "Pancakes"},
+            ]
+        )
+    result = CliRunner().invoke(
+        cli.cli,
+        [db_path, "select id, name from dogs", "--fmt", "plain", "--no-headers"],
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "1  Cleo\n2  Pancakes"
+
+
 def test_create_index(db_path):
     db = Database(db_path)
     assert [] == db["Gosh"].indexes


### PR DESCRIPTION
## Summary

Fixes #566

The `--no-headers` flag was silently ignored when combined with `--fmt` or `--table`. Headers appeared in the output regardless.

## Root Cause

The `--no-headers` flag was only checked in the CSV/TSV output branch (line 243). When `--fmt` or `--table` was used, `tabulate.tabulate()` was always called with `headers=headers`, bypassing the flag entirely. This affected both the `tables` command (line 240) and the `query`/`_execute_query` path (line 2148).

## Changes

- `sqlite_utils/cli.py`: Pass `headers=() if no_headers else headers` to both `tabulate.tabulate()` call sites. `tabulate` natively supports `headers=()` for suppressing header display.
- `tests/test_cli.py`: Added `test_output_table_no_headers` (parametrized over `plain` and `simple` formats) and `test_query_fmt_no_headers` (verifies the `query` command path).

## Testing

- [x] Full test suite passes (1039 passed, 16 skipped, 0 failures)
- [x] New tests fail when fix is reverted (verified)
- [x] No regressions from baseline (1036 → 1039 with 3 new tests)

```bash
python -m pytest tests/test_cli.py::test_output_table_no_headers tests/test_cli.py::test_query_fmt_no_headers -v
```

## Notes

Chose to make `--no-headers` work with `--fmt` rather than raising an error, since `tabulate` supports headerless output cleanly via `headers=()`. This keeps `--no-headers` consistent across all output modes (CSV, TSV, and tabulate formats).

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--729.org.readthedocs.build/en/729/

<!-- readthedocs-preview sqlite-utils end -->