### PR TITLE
fix(cli): avoid transform() when table missing (header-only CSV + detect-types)

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1176,7 +1176,7 @@ def insert_upsert_implementation(
                 )
             else:
                 raise
-        if tracker is not None:
+        if tracker is not None and db[table].exists():
             db.table(table).transform(types=tracker.types)
 
         # Clean up open file-like objects
@@ -2033,7 +2033,7 @@ def memory(
                 rows = (_flatten(row) for row in rows)
 
             db.table(file_table).insert_all(rows, alter=True)
-            if tracker is not None:
+            if tracker is not None and db[file_table].exists():
                 db.table(file_table).transform(types=tracker.types)
             # Add convenient t / t1 / t2 views
             view_names = ["t{}".format(i + 1)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2327,6 +2327,21 @@ def test_upsert_detect_types(tmpdir, option):
     ]
 
 
+def test_insert_csv_header_only_detect_types_no_crash(tmpdir):
+    """Header-only CSV with default type detection must not crash (issue #702)."""
+    db_path = str(tmpdir / "test.db")
+    data = "name,age,weight\n"
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "creatures", "-", "--csv"],
+        catch_exceptions=False,
+        input=data,
+    )
+    assert result.exit_code == 0
+    db = Database(db_path)
+    assert not db["creatures"].exists()
+
+
 def test_csv_detect_types_creates_real_columns(tmpdir):
     """Test that CSV import creates REAL columns for floats (default behavior)"""
     db_path = str(tmpdir / "test.db")


### PR DESCRIPTION
## Summary

Fixes #702.

When importing CSV with default `--detect-types`, a **header-only** file (no data rows) yields an empty insert. The table may not exist yet, but the CLI still called `Table.transform()` from the type tracker path, which asserts that the table exists.

Guard both code paths with `db[table].exists()` before calling `transform()`:

- `insert_upsert_implementation` (e.g. `sqlite-utils insert ... --csv`)
- the multi-file `memory` command path that uses the same tracker + `insert_all` + `transform` sequence

## Test

Added `test_insert_csv_header_only_detect_types_no_crash`: header-only CSV + default detection exits 0 and does not create a table (same net behavior as before for zero rows, without crashing).

## Verification

```bash
pytest tests/test_cli.py::test_insert_csv_header_only_detect_types_no_crash -v
```


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--730.org.readthedocs.build/en/730/

<!-- readthedocs-preview sqlite-utils end -->