### PR TITLE
fix: auto-commit delete_where()

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2905,9 +2905,10 @@ class Table(Queryable):
         sql = "delete from {}".format(quote_identifier(self.name))
         if where is not None:
             sql += " where " + where
-        self.db.execute(sql, where_args or [])
-        if analyze:
-            self.analyze()
+        with self.db.conn:
+            self.db.execute(sql, where_args or [])
+            if analyze:
+                self.analyze()
         return self
 
     def update(

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,3 +1,4 @@
+from sqlite_utils import Database
 def test_delete_rowid_table(fresh_db):
     table = fresh_db["table"]
     table.insert({"foo": 1}).last_pk
@@ -30,6 +31,19 @@ def test_delete_where_all(fresh_db):
     assert table.count == 10
     table.delete_where()
     assert table.count == 0
+
+
+def test_delete_where_all_auto_commits(db_path):
+    db = Database(db_path)
+    table = db["table"]
+    table.insert_all(({"id": i} for i in range(1, 6)), pk="id")
+    assert table.count == 5
+
+    table.delete_where()
+    assert table.count == 0
+
+    reopened = Database(db_path)
+    assert reopened["table"].count == 0
 
 
 def test_delete_where_analyze(fresh_db):


### PR DESCRIPTION
## Summary
- wrap `Table.delete_where()` in the same connection context manager used by `delete()` and `update()`
- make deletes visible to a new connection immediately instead of leaving them uncommitted
- add a file-backed regression test that reproduces the missing auto-commit behavior

## Testing
- `.venv/bin/python -m pytest tests/test_delete.py -q`
- `.venv/bin/python -m py_compile sqlite_utils/db.py tests/test_delete.py`
- manual repro: delete rows from a file-backed database, reopen it, verify row count stays at 0

Fixes #159

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--731.org.readthedocs.build/en/731/

<!-- readthedocs-preview sqlite-utils end -->