### PR TITLE
Guard transform when --detect-types CSV has only a header row (closes #702)

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1176,7 +1176,7 @@ def insert_upsert_implementation(
                 )
             else:
                 raise
-        if tracker is not None:
+        if tracker is not None and db.table(table).exists():
             db.table(table).transform(types=tracker.types)
 
         # Clean up open file-like objects

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2305,6 +2305,21 @@ def test_insert_detect_types(tmpdir, option):
     ]
 
 
+def test_insert_detect_types_header_only_csv(tmpdir):
+    """Test that --detect-types does not crash for CSV with only a header row"""
+    db_path = str(tmpdir / "test.db")
+    data = "name,age,weight\n"
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "creatures", "-", "--csv", "--detect-types"],
+        catch_exceptions=False,
+        input=data,
+    )
+    assert result.exit_code == 0
+    db = Database(db_path)
+    assert "creatures" not in db.table_names()
+
+
 @pytest.mark.parametrize("option", (None, "-d", "--detect-types"))
 def test_upsert_detect_types(tmpdir, option):
     """Test that type detection is now the default behavior for upsert"""


### PR DESCRIPTION
Fixes #702.

When `sqlite-utils insert --csv --detect-types` is given a CSV file that contains only the header row (no data rows), the table is never created — but the post-insert call to `db.table(table).transform(types=tracker.types)` still runs and trips an assertion:

    AssertionError: Cannot transform a table that doesn't exist yet

This adds the `db.table(table).exists()` guard suggested by the issue author (@nis-djom), plus a regression test (`tests/test_cli.py::test_insert_detect_types_header_only_csv`) that exercises the exact scenario from the issue body.

Local `pytest -q` on the patched branch: 1041 passed, 16 skipped, 6.40s.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--733.org.readthedocs.build/en/733/

<!-- readthedocs-preview sqlite-utils end -->