### PR TITLE
docs: set smartquotes_action="qe" so '--' doesn't render as an en dash

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,14 @@ highlight_language = "none"
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Smart-quote substitutions, but skip the dash transformations. Without this,
+# "--" inside cross-references like :ref:`insert --convert <...>` gets rewritten
+# to en/em dashes (the en dash "–"), which is the bug from
+# https://github.com/simonw/sqlite-utils/issues/493. The default action is
+# "qDe"; dropping the "D" keeps SmartQuotes for quotes ("q") and ellipses
+# ("e") while leaving "--" alone.
+smartquotes_action = "qe"
+
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
Closes #493.

The docs already escape `--` as `\--` inside cross-references like:

```rst
:ref:\`insert \--convert <cli_insert_convert>\`
```

but Sphinx's smart-quotes filter still rewrites the two dashes to an en dash in the rendered HTML, so the page reads "insert –convert" / "query –functions" instead of the actual flag names.

The smartquotes default action is `qDe` (quotes + dashes + ellipses). Dropped the `D` so we only get smart quotes for actual quotes and ellipses; dashes pass through. Quotes elsewhere in the docs (e.g. "row" wrapping examples) still get curly-quoted as before.

Tested locally with `sphinx-build -b html docs docs/_build/html`. The line at `cli.rst:2789` now renders as `insert --convert` and `query --functions` instead of with en dashes.

The existing `\--` escapes are now redundant but harmless, so I left them to keep this diff minimal — easy follow-up if you want to clean them up later.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--735.org.readthedocs.build/en/735/

<!-- readthedocs-preview sqlite-utils end -->