### PR TITLE
Don't transform empty CSV table that was never created

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1175,7 +1175,9 @@ def insert_upsert_implementation(
                 )
             else:
                 raise
-        if tracker is not None:
+        if tracker is not None and db.table(table).exists():
+            # A header-only CSV creates no table, so there is nothing to
+            # retype - skip the transform to avoid the assertion in it.
             db.table(table).transform(types=tracker.types)
 
         # Clean up open file-like objects
@@ -2032,7 +2034,7 @@ def memory(
                 rows = (_flatten(row) for row in rows)
 
             db.table(file_table).insert_all(rows, alter=True)
-            if tracker is not None:
+            if tracker is not None and db.table(file_table).exists():
                 db.table(file_table).transform(types=tracker.types)
             # Add convenient t / t1 / t2 views
             view_names = ["t{}".format(i + 1)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2296,6 +2296,21 @@ def test_insert_detect_types(tmpdir, option):
     ]
 
 
+def test_insert_detect_types_header_only_csv(tmpdir):
+    """A CSV that is only a header row creates no table; --detect-types should
+    not crash trying to transform it. Regression for #702."""
+    db_path = str(tmpdir / "test.db")
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "creatures", "-", "--csv", "--detect-types"],
+        catch_exceptions=False,
+        input="name,age,weight\n",
+    )
+    assert result.exit_code == 0
+    db = Database(db_path)
+    assert "creatures" not in db.table_names()
+
+
 @pytest.mark.parametrize("option", (None, "-d", "--detect-types"))
 def test_upsert_detect_types(tmpdir, option):
     """Test that type detection is now the default behavior for upsert"""


### PR DESCRIPTION
Closes #702.

When a CSV file is header-only, \`insert_all\` is a no-op so the table never gets created, but the \`--detect-types\` path still calls \`transform(types=tracker.types)\` afterwards and \`transform\` asserts \`table.exists()\`. Result is the \`AssertionError: Cannot transform a table that doesn't exist yet\` traceback from the issue.

Gate the \`transform\` call on \`table.exists()\` so the empty case is a clean no-op. Applied the same guard to the analogous loop further down in \`memory\`-style multi-file insertion. Added a regression test that fails on main and passes here.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--736.org.readthedocs.build/en/736/

<!-- readthedocs-preview sqlite-utils end -->