### PR TITLE
docs: render --convert and --functions literally in install section

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2786,7 +2786,7 @@ See this `SpatiaLite Cookbook recipe <http://www.gaia-gis.it/gaia-sins/spatialit
 Installing packages
 ===================
 
-The :ref:`convert command <cli_convert>` and the :ref:`insert -\\-convert <cli_insert_convert>` and :ref:`query -\\-functions <cli_query_functions>` options can be provided with a Python script that imports additional modules from the ``sqlite-utils`` environment.
+The :ref:`convert command <cli_convert>`, the ``--convert`` option to :ref:`insert <cli_insert_convert>`, and the ``--functions`` option to :ref:`query <cli_query_functions>` can be provided with a Python script that imports additional modules from the ``sqlite-utils`` environment.
 
 You can install packages from PyPI directly into the correct environment using ``sqlite-utils install <package>``. This is a wrapper around ``pip install``.
 


### PR DESCRIPTION
Sphinx's smartquotes was turning \`--convert\` and \`--functions\` into en-dashes because they were sitting in the display text of a \`:ref:\` block, where escapes don't reach. Reworded the sentence so the literal options live inline in code spans (\`\`--convert\`\` / \`\`--functions\`\`) and the \`:ref:\` links point at the commands themselves. Same content, but the dashes render right now.

Closes #493.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--737.org.readthedocs.build/en/737/

<!-- readthedocs-preview sqlite-utils end -->