### PR TITLE
cli: honor --no-headers for table and tabulate-style formats

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -236,7 +236,8 @@ def tables(
             yield row
 
     if table or fmt:
-        print(tabulate.tabulate(_iter(), headers=headers, tablefmt=fmt or "simple"))
+        tab_headers = () if no_headers else headers
+        print(tabulate.tabulate(_iter(), headers=tab_headers, tablefmt=fmt or "simple"))
     elif csv or tsv:
         writer = csv_std.writer(sys.stdout, dialect="excel-tab" if tsv else "excel")
         if not no_headers:
@@ -2137,9 +2138,10 @@ def _execute_query(
                 else:
                     sys.stdout.write(str(data) + "\n")
         elif fmt or table:
+            tab_headers = () if no_headers else headers
             print(
                 tabulate.tabulate(
-                    list(cursor), headers=headers, tablefmt=fmt or "simple"
+                    list(cursor), headers=tab_headers, tablefmt=fmt or "simple"
                 )
             )
         elif csv or tsv:


### PR DESCRIPTION
Closes #566.

`--no-headers` was already respected for `csv`/`tsv` output, but the two `tabulate.tabulate` calls (used for `--table` and `--fmt`) passed `headers=headers` unconditionally, so the header row still printed. Pass `()` instead when `--no-headers` is set.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--740.org.readthedocs.build/en/740/

<!-- readthedocs-preview sqlite-utils end -->