### PR TITLE
cli: output JSON without escaping non-ASCII characters

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -3317,7 +3317,7 @@ def output_rows(iterator, headers, nl, arrays, json_cols):
             data = dict(zip(headers, data))
         line = "{firstchar}{serialized}{maybecomma}{lastchar}".format(
             firstchar=("[" if first else " ") if not nl else "",
-            serialized=json.dumps(data, default=json_binary),
+            serialized=json.dumps(data, default=json_binary, ensure_ascii=False),
             maybecomma="," if (not nl and not is_last) else "",
             lastchar="]" if (is_last and not nl) else "",
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -738,6 +738,17 @@ def test_query_json(db_path, sql, args, expected):
     assert expected == result.output.strip()
 
 
+def test_query_json_unicode(db_path):
+    # Regression for #625: JSON output should keep non-ASCII characters
+    # as themselves, not as \u-escapes.
+    db = Database(db_path)
+    with db.conn:
+        db["t"].insert({"id": 1, "text": "Japanese 日本語"})
+    result = CliRunner().invoke(cli.cli, [db_path, "select id, text from t"])
+    assert "日本語" in result.output
+    assert "\\u65e5" not in result.output
+
+
 def test_query_json_empty(db_path):
     result = CliRunner().invoke(
         cli.cli,


### PR DESCRIPTION
Closes:
- #625

`json.dumps` defaults to `ensure_ascii=True`, so `output_rows` emitted `日本語` instead of `日本語` for Japanese rows. The CSV path already shows the characters verbatim — the JSON path should too. Pass `ensure_ascii=False` so the bytes match what the CSV output (and the database itself) holds.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--741.org.readthedocs.build/en/741/

<!-- readthedocs-preview sqlite-utils end -->