### PR TITLE
fix: validate response shape before indexing in test_query_load_exten...

### DIFF
--- a/tests/test_gis.py
+++ b/tests/test_gis.py
@@ -117,7 +117,9 @@ def test_query_load_extension(use_spatialite_shortcut):
         ],
     )
     assert result.exit_code == 0, result.stdout
-    assert ["spatialite_version()"] == list(json.loads(result.output)[0].keys())
+    rows = json.loads(result.output)
+    assert len(rows) == 1
+    assert ["spatialite_version()"] == list(rows[0].keys())
 
 
 def test_cli_create_spatialite(tmpdir):


### PR DESCRIPTION
## Summary
`test_query_load_extension` called `json.loads(result.output)[0]` without first checking that the parsed list is non-empty, so any empty or truncated CLI output would raise an `IndexError` instead of a meaningful assertion failure. The fix extracts the parsed result into a local variable and asserts its length before indexing.

## Why it matters
If the CLI silently produces no rows (e.g. due to a regression in the output serialiser or an unexpected empty result set), the test crashes with an opaque `IndexError` rather than failing with a diagnostic message pointing at the actual assertion.

## Testing
The new `assert len(rows) == 1` line fires before the index access; all previously-passing inputs still reach and satisfy the original key-shape assertion unchanged.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--743.org.readthedocs.build/en/743/

<!-- readthedocs-preview sqlite-utils end -->