### PR TITLE
docs: document `PRAGMA temp_store` for VACUUM on large databases

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -3107,6 +3107,16 @@ You can optimize your database by running VACUUM against it like so:
 .. note::
     In the CLI: :ref:`sqlite-utils vacuum <cli_vacuum>`
 
+Running VACUUM (or other operations that rebuild the database, such as :ref:`table.extract() <python_api_extract>`) against a very large database may fail with ``OperationalError: database or disk is full`` when ``/tmp`` does not have enough space for the temporary rebuild. SQLite uses a temporary file by default; you can ask it to use memory instead by setting `PRAGMA temp_store <https://www.sqlite.org/pragma.html#pragma_temp_store>`__ to ``MEMORY`` on the connection:
+
+.. code-block:: python
+
+    db = Database("my_database.db")
+    db.execute("PRAGMA temp_store = MEMORY")
+    db.vacuum()
+
+This makes SQLite hold the temporary state in RAM, which avoids the ``/tmp`` size limit at the cost of additional memory usage.
+
 .. _python_api_wal:
 
 WAL mode


### PR DESCRIPTION
Closes #430.

The maintainer wrote in https://github.com/simonw/sqlite-utils/issues/430#issuecomment-1155309239:

> It looks like `PRAGMA temp_store` was the right option to use here ... I'm going to turn this into a help-wanted documentation issue.

This adds a short paragraph to the existing `Vacuum` section in `docs/python-api.rst` describing the `/tmp`-fills-up symptom that triggered the issue and the `PRAGMA temp_store = MEMORY` workaround, with a runnable example and a link to the upstream SQLite `PRAGMA temp_store` docs.

Verified locally:

    >>> from sqlite_utils import Database
    >>> db = Database(memory=True)
    >>> db.execute('PRAGMA temp_store = MEMORY')
    >>> db.execute('PRAGMA temp_store').fetchone()
    (2,)
    >>> db.vacuum()

`sphinx-build -n docs docs/_build` produces no new warnings on the modified section (pre-existing `reference.rst` warnings are unchanged).

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--744.org.readthedocs.build/en/744/

<!-- readthedocs-preview sqlite-utils end -->