### PR TITLE
Fix KeyError in insert_all when pk column is missing from a single record

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -3608,12 +3608,20 @@ class Table(Queryable):
                 if (hash_id or pk) and self.last_rowid:
                     # Set self.last_pk to the pk(s) for that rowid
                     row = list(self.rows_where("rowid = ?", [self.last_rowid]))[0]
-                    if hash_id:
-                        self.last_pk = row[hash_id]
-                    elif isinstance(pk, str):
-                        self.last_pk = row[pk]
+                    pk_cols = (
+                        [hash_id]
+                        if hash_id
+                        else ([pk] if isinstance(pk, str) else list(pk))
+                    )
+                    if all(col in row for col in pk_cols):
+                        if hash_id or isinstance(pk, str):
+                            self.last_pk = row[pk_cols[0]]
+                        else:
+                            self.last_pk = tuple(row[col] for col in pk_cols)
                     else:
-                        self.last_pk = tuple(row[p] for p in pk)
+                        # Named pk column(s) are not present in the table - fall
+                        # back to the rowid, matching the multi-row behaviour
+                        self.last_pk = self.last_rowid
                 else:
                     self.last_pk = self.last_rowid
             else:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -670,6 +670,22 @@ def test_insert_all_with_extra_columns_in_later_chunks(fresh_db):
     ]
 
 
+@pytest.mark.parametrize("num_rows", (0, 1, 2, 3, 10))
+def test_insert_all_pk_not_in_records(fresh_db, num_rows):
+    # https://github.com/simonw/sqlite-utils/issues/732
+    # Naming a pk= column that is absent from the records should behave the
+    # same regardless of how many rows are inserted - previously a single row
+    # raised a KeyError while other row counts did not.
+    fresh_db.conn.execute("CREATE TABLE t (a TEXT, b INT, PRIMARY KEY (a, b))")
+    rows = [{"a": "x{}".format(i), "b": i} for i in range(num_rows)]
+    table = fresh_db.table("t")
+    table.insert_all(rows, pk="not_a_column", alter=True)
+    assert table.count == num_rows
+    if num_rows == 1:
+        # Falls back to the rowid since the named pk column does not exist
+        assert table.last_pk == table.last_rowid
+
+
 def test_bulk_insert_more_than_999_values(fresh_db):
     "Inserting 100 items with 11 columns should work"
     fresh_db["big"].insert_all(


### PR DESCRIPTION
Fixes #732

## The bug

`insert_all()` with a `pk=` column that isn't present in the records raised a `KeyError` — but only when inserting exactly one row. Every other row count succeeded:

```python
import sqlite_utils

for n in [0, 1, 2, 3, 10]:
    db = sqlite_utils.Database(memory=True)
    db.conn.execute("CREATE TABLE t (a TEXT, b INT, PRIMARY KEY (a, b))")
    rows = [{"a": f"x{i}", "b": i} for i in range(n)]
    try:
        db.table("t").insert_all(rows, pk="not_a_column", alter=True)
        print(f"n={n}: ok")
    except KeyError as e:
        print(f"n={n}: KeyError {e}")
```

```
n=0: ok
n=1: KeyError 'not_a_column'
n=2: ok
n=3: ok
n=10: ok
```

## Root cause

The single-record branch that populates `last_pk` reads the pk value straight out of the just-inserted row (`row[pk]`). When the named pk column doesn't actually exist on the table, that lookup throws. The multi-record path doesn't go through this branch, hence the inconsistency.

## Fix

Check that the named pk column(s) are present on the row before reading them, and fall back to the rowid otherwise — the same fallback already used when no pk is given. Single-row inserts now behave like every other row count.

## Testing

Added `test_insert_all_pk_not_in_records`, parametrized over 0/1/2/3/10 rows, which fails on `main` (KeyError for the single-row case) and passes with this change. Full test suite, black, flake8 and mypy all pass locally.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--745.org.readthedocs.build/en/745/

<!-- readthedocs-preview sqlite-utils end -->