### PR TITLE
fix: quote convert dry-run identifiers

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -3088,12 +3088,12 @@ def convert(
         db.conn.create_function("preview_transform", 1, preview)
         sql = """
             select
-                [{column}] as value,
-                preview_transform([{column}]) as preview
-            from [{table}]{where} limit 10
+                {column} as value,
+                preview_transform({column}) as preview
+            from {table}{where} limit 10
         """.format(
-            column=columns[0],
-            table=table,
+            column=quote_identifier(columns[0]),
+            table=quote_identifier(table),
             where=" where {}".format(where) if where is not None else "",
         )
         for row in db.conn.execute(sql, where_args).fetchall():

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -179,6 +179,25 @@ def test_convert_dryrun(test_db_and_path):
     assert result.output.strip().split("\n")[-1] == "Would affect 1 row"
 
 
+def test_convert_dryrun_identifier_with_closing_bracket(tmpdir):
+    db_path = str(pathlib.Path(tmpdir) / "data.db")
+    db = sqlite_utils.Database(db_path)
+    db["example]table"].insert({"value]x": "alpha"})
+    result = CliRunner().invoke(
+        cli.cli,
+        [
+            "convert",
+            db_path,
+            "example]table",
+            "value]x",
+            "value.upper()",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "alpha\n --- becomes:\nALPHA\n\nWould affect 1 row"
+
+
 def test_convert_multi_dryrun(test_db_and_path):
     db_path = test_db_and_path[1]
     result = CliRunner().invoke(


### PR DESCRIPTION
## Summary

Fixes `convert --dry-run` so table and column identifiers are quoted using the existing `quote_identifier()` helper.

## What changed

- Replaced square-bracket identifier interpolation in the dry-run preview query with `quote_identifier()`.
- Added a regression test for a table and column containing `]`.

## Why

The normal `convert` path already uses `quote_identifier()`, but the dry-run preview path built SQL using square brackets directly. That meant valid identifiers containing `]` could fail in `--dry-run` even though the actual conversion path handled them correctly.

This keeps dry-run behavior consistent with the main conversion path.

## Tests

Ran:

```bash
python -m pytest tests/test_cli_convert.py -q
```

Result:

```text
46 passed
```

## Compatibility notes

This only changes generated SQL for the dry-run preview query. Existing ordinary table and column names should behave the same, while identifiers requiring escaping now use the same quoting approach as the main convert implementation.


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--747.org.readthedocs.build/en/747/

<!-- readthedocs-preview sqlite-utils end -->