### PR TITLE
fix: bind attach database path

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -534,12 +534,8 @@ class Database:
         :param alias: Alias name to use
         :param filepath: Path to SQLite database file on disk
         """
-        attach_sql = """
-            ATTACH DATABASE '{}' AS {};
-        """.format(
-            str(pathlib.Path(filepath).resolve()), quote_identifier(alias)
-        ).strip()
-        self.execute(attach_sql)
+        attach_sql = "ATTACH DATABASE ? AS {};".format(quote_identifier(alias))
+        self.execute(attach_sql, [str(pathlib.Path(filepath).resolve())])
 
     def query(
         self, sql: str, params: Optional[Union[Sequence, Dict[str, Any]]] = None

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -14,3 +14,20 @@ def test_attach(tmpdir):
     assert db.execute(
         "select * from foo union all select * from bar.bar"
     ).fetchall() == [(1, "foo"), (1, "bar")]
+
+
+def test_attach_filepath_with_apostrophe(tmpdir):
+    foo_path = str(tmpdir / "foo.db")
+    bar_dir = tmpdir / "has'apostrophe"
+    bar_dir.mkdir()
+    bar_path = str(bar_dir / "bar.db")
+    db = Database(foo_path)
+    with db.conn:
+        db["foo"].insert({"id": 1, "text": "foo"})
+    db2 = Database(bar_path)
+    with db2.conn:
+        db2["bar"].insert({"id": 1, "text": "bar"})
+    db.attach("bar", bar_path)
+    assert db.execute(
+        "select * from foo union all select * from bar.bar"
+    ).fetchall() == [(1, "foo"), (1, "bar")]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2239,6 +2239,30 @@ def test_attach(tmpdir):
     ]
 
 
+def test_attach_filepath_with_apostrophe(tmpdir):
+    foo_path = str(tmpdir / "foo.db")
+    bar_dir = tmpdir / "has'apostrophe"
+    bar_dir.mkdir()
+    bar_path = str(bar_dir / "bar.db")
+    db = Database(foo_path)
+    with db.conn:
+        db["foo"].insert({"id": 1, "text": "foo"})
+    db2 = Database(bar_path)
+    with db2.conn:
+        db2["bar"].insert({"id": 1, "text": "bar"})
+    db.attach("bar", bar_path)
+    sql = "select * from foo union all select * from bar.bar"
+    result = CliRunner().invoke(
+        cli.cli,
+        [foo_path, "--attach", "bar", bar_path, sql],
+        catch_exceptions=False,
+    )
+    assert json.loads(result.output) == [
+        {"id": 1, "text": "foo"},
+        {"id": 1, "text": "bar"},
+    ]
+
+
 def test_csv_insert_bom(tmpdir):
     db_path = str(tmpdir / "test.db")
     bom_csv_path = str(tmpdir / "bom.csv")


### PR DESCRIPTION
## Summary

This updates `Database.attach()` to bind the attached database filepath as a SQL parameter instead of interpolating it into the `ATTACH DATABASE` statement.

## What changed

- Bind the resolved filepath with `ATTACH DATABASE ? AS ...`
- Keep existing alias quoting behavior unchanged
- Add Python API coverage for attached database paths containing an apostrophe
- Add CLI `--attach` coverage for attached database paths containing an apostrophe

## Why

Filepaths can contain apostrophes, and binding the path keeps `attach()` working for those valid paths without changing alias handling.

## Tests

Focused Docker validation:

```bash
python -m pytest tests/test_attach.py tests/test_cli.py::test_attach tests/test_cli.py::test_attach_filepath_with_apostrophe -q
```

Result:

```text
4 passed
```

## Compatibility notes

This keeps path resolution and alias quoting behavior unchanged. The SQL text now uses a bound parameter for the filepath, which is consistent with parameterized SQLite execution.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--748.org.readthedocs.build/en/748/

<!-- readthedocs-preview sqlite-utils end -->