### PR TITLE
Honor --no-headers for --fmt and --table output (#566)

### DIFF
--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -115,7 +115,7 @@ See :ref:`cli_query`.
       --arrays                    Output rows as arrays instead of objects
       --csv                       Output CSV
       --tsv                       Output TSV
-      --no-headers                Omit CSV headers
+      --no-headers                Omit headers from CSV/TSV and table/--fmt output
       -t, --table                 Output as a formatted table
       --fmt TEXT                  Table format - one of asciidoc, colon_grid,
                                   double_grid, double_outline, fancy_grid,
@@ -184,7 +184,7 @@ See :ref:`cli_memory`.
       --arrays                    Output rows as arrays instead of objects
       --csv                       Output CSV
       --tsv                       Output TSV
-      --no-headers                Omit CSV headers
+      --no-headers                Omit headers from CSV/TSV and table/--fmt output
       -t, --table                 Output as a formatted table
       --fmt TEXT                  Table format - one of asciidoc, colon_grid,
                                   double_grid, double_outline, fancy_grid,
@@ -423,7 +423,7 @@ See :ref:`cli_search`.
       --arrays               Output rows as arrays instead of objects
       --csv                  Output CSV
       --tsv                  Output TSV
-      --no-headers           Omit CSV headers
+      --no-headers           Omit headers from CSV/TSV and table/--fmt output
       -t, --table            Output as a formatted table
       --fmt TEXT             Table format - one of asciidoc, colon_grid,
                              double_grid, double_outline, fancy_grid, fancy_outline,
@@ -689,7 +689,7 @@ See :ref:`cli_tables`.
       --arrays               Output rows as arrays instead of objects
       --csv                  Output CSV
       --tsv                  Output TSV
-      --no-headers           Omit CSV headers
+      --no-headers           Omit headers from CSV/TSV and table/--fmt output
       -t, --table            Output as a formatted table
       --fmt TEXT             Table format - one of asciidoc, colon_grid,
                              double_grid, double_outline, fancy_grid, fancy_outline,
@@ -731,7 +731,7 @@ See :ref:`cli_views`.
       --arrays               Output rows as arrays instead of objects
       --csv                  Output CSV
       --tsv                  Output TSV
-      --no-headers           Omit CSV headers
+      --no-headers           Omit headers from CSV/TSV and table/--fmt output
       -t, --table            Output as a formatted table
       --fmt TEXT             Table format - one of asciidoc, colon_grid,
                              double_grid, double_outline, fancy_grid, fancy_outline,
@@ -778,7 +778,7 @@ See :ref:`cli_rows`.
       --arrays                    Output rows as arrays instead of objects
       --csv                       Output CSV
       --tsv                       Output TSV
-      --no-headers                Omit CSV headers
+      --no-headers                Omit headers from CSV/TSV and table/--fmt output
       -t, --table                 Output as a formatted table
       --fmt TEXT                  Table format - one of asciidoc, colon_grid,
                                   double_grid, double_outline, fancy_grid,
@@ -818,7 +818,7 @@ See :ref:`cli_triggers`.
       --arrays               Output rows as arrays instead of objects
       --csv                  Output CSV
       --tsv                  Output TSV
-      --no-headers           Omit CSV headers
+      --no-headers           Omit headers from CSV/TSV and table/--fmt output
       -t, --table            Output as a formatted table
       --fmt TEXT             Table format - one of asciidoc, colon_grid,
                              double_grid, double_outline, fancy_grid, fancy_outline,
@@ -858,7 +858,7 @@ See :ref:`cli_indexes`.
       --arrays               Output rows as arrays instead of objects
       --csv                  Output CSV
       --tsv                  Output TSV
-      --no-headers           Omit CSV headers
+      --no-headers           Omit headers from CSV/TSV and table/--fmt output
       -t, --table            Output as a formatted table
       --fmt TEXT             Table format - one of asciidoc, colon_grid,
                              double_grid, double_outline, fancy_grid, fancy_outline,

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -107,7 +107,11 @@ def output_options(fn):
             ),
             click.option("--csv", is_flag=True, help="Output CSV"),
             click.option("--tsv", is_flag=True, help="Output TSV"),
-            click.option("--no-headers", is_flag=True, help="Omit CSV headers"),
+            click.option(
+                "--no-headers",
+                is_flag=True,
+                help="Omit headers from CSV/TSV and table/--fmt output",
+            ),
             click.option(
                 "-t", "--table", is_flag=True, help="Output as a formatted table"
             ),
@@ -236,7 +240,13 @@ def tables(
             yield row
 
     if table or fmt:
-        print(tabulate.tabulate(_iter(), headers=headers, tablefmt=fmt or "simple"))
+        print(
+            tabulate.tabulate(
+                _iter(),
+                headers=() if no_headers else headers,
+                tablefmt=fmt or "simple",
+            )
+        )
     elif csv or tsv:
         writer = csv_std.writer(sys.stdout, dialect="excel-tab" if tsv else "excel")
         if not no_headers:
@@ -2139,7 +2149,9 @@ def _execute_query(
         elif fmt or table:
             print(
                 tabulate.tabulate(
-                    list(cursor), headers=headers, tablefmt=fmt or "simple"
+                    list(cursor),
+                    headers=() if no_headers else headers,
+                    tablefmt=fmt or "simple",
                 )
             )
         elif csv or tsv:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,6 +195,50 @@ def test_output_table(db_path, options, expected):
     assert expected == result.output.strip()
 
 
+@pytest.mark.parametrize(
+    "fmt_option", [["--fmt", "simple"], ["-t"], ["--fmt", "github"]]
+)
+def test_output_table_no_headers(db_path, fmt_option):
+    # --no-headers should omit the header row from --fmt/--table output too, not
+    # just from --csv/--tsv (#566). Previously the flag was silently ignored for
+    # tabulate formats and the column names were always printed.
+    db = Database(db_path)
+    with db.conn:
+        db["dogs"].insert_all(
+            [
+                {"id": 1, "name": "Cleo", "age": 4},
+                {"id": 2, "name": "Pancakes", "age": 2},
+            ]
+        )
+    sql = "select id, name, age from dogs order by id"
+
+    with_headers = CliRunner().invoke(cli.cli, ["query", db_path, sql] + fmt_option)
+    without_headers = CliRunner().invoke(
+        cli.cli, ["query", db_path, sql] + fmt_option + ["--no-headers"]
+    )
+    assert with_headers.exit_code == 0
+    assert without_headers.exit_code == 0
+
+    # The column names appear when headers are shown, and must not appear at all
+    # once --no-headers is passed.
+    assert "name" in with_headers.output
+    for header in ("id", "name", "age"):
+        assert (
+            header not in without_headers.output
+        ), f"header {header!r} leaked into --no-headers output"
+    # The data is still all present.
+    for value in ("Cleo", "Pancakes", "1", "2", "4"):
+        assert value in without_headers.output
+
+    # The rows command shares the same code path.
+    rows_no_headers = CliRunner().invoke(
+        cli.cli, ["rows", db_path, "dogs"] + fmt_option + ["--no-headers"]
+    )
+    assert rows_no_headers.exit_code == 0
+    assert "name" not in rows_no_headers.output
+    assert "Cleo" in rows_no_headers.output
+
+
 def test_create_index(db_path):
     db = Database(db_path)
     assert [] == db["Gosh"].indexes


### PR DESCRIPTION
Refs #566.

## Problem

`--no-headers` was only honored for `--csv`/`--tsv` output. For the tabulate formats (`--fmt ...` and `-t`/`--table`) the flag was **silently ignored**, so the column-name header row was always printed:

```
$ sqlite-utils query library.db 'select asin from audible' --fmt plain --no-headers
asin        # <- should not be here
0062804006
0062891421
```

The two `tabulate.tabulate(...)` call sites (the `query`/`memory` output and the `rows`/`tables` output) always passed `headers=headers` regardless of the flag.

## Fix

Both call sites now pass `headers=() if no_headers else headers`. `tabulate` renders headerless output cleanly for every format (`plain`, `simple`, `github`, `grid`, `rst`, …), so `--no-headers` now works consistently across CSV, TSV and all `--fmt`/`--table` formats. Default output (headers shown) is unchanged, and the CSV/TSV path is untouched.

```
$ sqlite-utils query library.db 'select asin from audible' --fmt plain --no-headers
0062804006
0062891421
```

I went with making the flag do what its name says (rather than raising an error on `--fmt` + `--no-headers`) because `tabulate` supports headerless rendering for all formats and this matches the documented purpose of the flag — and the use case in the issue (piping a single column into `xargs`/unix tools) is a legitimate one.

The `--no-headers` help text previously said "Omit CSV headers"; it now reads "Omit headers from CSV/TSV and table/--fmt output", and `docs/cli-reference.rst` is regenerated via cog to match.

## Tests

Added `test_output_table_no_headers`, parametrized over `--fmt simple`, `-t` and `--fmt github`, asserting the header row is omitted (and the data preserved) for both the `query` and `rows` commands.

- Full suite: **1042 passed, 17 skipped** locally.
- `black . --check`, `cog --check README.md docs/*.rst` and `codespell` all pass.


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--751.org.readthedocs.build/en/751/

<!-- readthedocs-preview sqlite-utils end -->