### PR TITLE
Raise ValueError instead of assert for conflicting insert_all() options

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -3464,15 +3464,15 @@ class Table(Queryable):
         if upsert and (not pk and not hash_id):
             raise PrimaryKeyRequired("upsert() requires a pk")
 
-        assert not (hash_id and pk), "Use either pk= or hash_id="
+        if hash_id and pk:
+            raise ValueError("Use either pk= or hash_id=")
         if hash_id_columns and (hash_id is None):
             hash_id = "id"
         if hash_id:
             pk = hash_id
 
-        assert not (
-            ignore and replace
-        ), "Use either ignore=True or replace=True, not both"
+        if ignore and replace:
+            raise ValueError("Use either ignore=True or replace=True, not both")
         all_columns = []
         first = True
         num_records_processed = 0

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -950,6 +950,26 @@ def test_insert_hash_id(fresh_db):
     assert dogs.count == 1
 
 
+def test_insert_all_pk_and_hash_id_raises_value_error(fresh_db):
+    # pk= and hash_id= are mutually exclusive. This must raise a ValueError
+    # rather than a bare AssertionError, which is silently stripped under
+    # python -O and so would let the contradictory call through.
+    with pytest.raises(ValueError, match="Use either pk= or hash_id="):
+        fresh_db["dogs"].insert_all(
+            [{"id": 1, "name": "Cleo"}], pk="id", hash_id="hash"
+        )
+
+
+def test_insert_all_ignore_and_replace_raises_value_error(fresh_db):
+    # ignore=True and replace=True are mutually exclusive.
+    with pytest.raises(
+        ValueError, match="Use either ignore=True or replace=True, not both"
+    ):
+        fresh_db["dogs"].insert_all(
+            [{"id": 1, "name": "Cleo"}], ignore=True, replace=True
+        )
+
+
 @pytest.mark.parametrize("use_table_factory", [True, False])
 def test_insert_hash_id_columns(fresh_db, use_table_factory):
     if use_table_factory:


### PR DESCRIPTION
`insert_all()` validates two mutually-exclusive argument pairs — `pk=`/`hash_id=` and `ignore=`/`replace=` — with bare `assert` statements:

```python
assert not (hash_id and pk), "Use either pk= or hash_id="
...
assert not (ignore and replace), "Use either ignore=True or replace=True, not both"
```

Two problems:

1. `assert` statements are stripped when Python runs under `-O`/`-OO`, so on optimized deployments these checks vanish entirely and a contradictory call (e.g. `insert_all(rows, pk="id", hash_id="hash")`) silently proceeds instead of being rejected.
2. When they do fire they raise `AssertionError`, which is inconsistent with the neighbouring validation a couple of lines above that raises `PrimaryKeyRequired` / `ValueError` for the same kind of argument problem.

This replaces both asserts with explicit `ValueError` raises (same messages) and adds regression tests for the two conflicts. No behaviour change for valid calls.

Full test suite passes (1042 passed, 16 skipped); `black`/`flake8` clean.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--753.org.readthedocs.build/en/753/

<!-- readthedocs-preview sqlite-utils end -->