### PR TITLE
Fix transform() corrupting TRUE/FALSE/NULL column defaults into strings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,6 +42,10 @@ Column names passed to Python API methods are now matched against the table sche
 - Foreign key columns are validated and recorded using the casing of the actual schema columns, in ``foreign_keys=`` when creating tables, ``db.add_foreign_keys()``, ``table.add_foreign_key()`` and ``table.add_column(fk_col=...)``. Duplicate foreign key detection is also case-insensitive.
 - ``table.create()`` with ``pk=``, ``not_null=``, ``defaults=`` or ``column_order=`` referencing columns using different casing no longer creates an unwanted extra primary key column or raises a ``ValueError``.
 
+Everything else:
+
+- Fixed a bug where ``table.transform()`` could convert ``DEFAULT TRUE``, ``DEFAULT FALSE`` and ``DEFAULT NULL`` column defaults into quoted string defaults when rebuilding a table. Thanks, `Vincent Gao <https://github.com/gaoflow>`__. (`#764 <https://github.com/simonw/sqlite-utils/pull/764>`__)
+
 .. _v4_0rc2:
 
 4.0rc2 (2026-07-04)

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -710,7 +710,7 @@ class Database:
         if str(value).upper() in ("CURRENT_TIME", "CURRENT_DATE", "CURRENT_TIMESTAMP"):
             return value
 
-        if str(value).upper() in ("TRUE", "FALSE", "NULL"):
+        if isinstance(value, str) and value.upper() in ("TRUE", "FALSE", "NULL"):
             # Keyword literals must stay unquoted; quoting them would turn the
             # default into a string ('TRUE' instead of 1, 'NULL' instead of null).
             return value

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -710,6 +710,11 @@ class Database:
         if str(value).upper() in ("CURRENT_TIME", "CURRENT_DATE", "CURRENT_TIMESTAMP"):
             return value
 
+        if str(value).upper() in ("TRUE", "FALSE", "NULL"):
+            # Keyword literals must stay unquoted; quoting them would turn the
+            # default into a string ('TRUE' instead of 1, 'NULL' instead of null).
+            return value
+
         if str(value).endswith(")"):
             # Expr
             return "({})".format(value)

--- a/tests/test_default_value.py
+++ b/tests/test_default_value.py
@@ -21,6 +21,11 @@ EXAMPLES = [
     # Strings
     ("TEXT DEFAULT 'CURRENT_TIMESTAMP'", "'CURRENT_TIMESTAMP'", "'CURRENT_TIMESTAMP'"),
     ('TEXT DEFAULT "CURRENT_TIMESTAMP"', '"CURRENT_TIMESTAMP"', '"CURRENT_TIMESTAMP"'),
+    # Boolean and null keyword literals must stay unquoted
+    ("INTEGER DEFAULT TRUE", "TRUE", "TRUE"),
+    ("INTEGER DEFAULT FALSE", "FALSE", "FALSE"),
+    ("INTEGER DEFAULT true", "true", "true"),
+    ("TEXT DEFAULT NULL", "NULL", "NULL"),
 ]
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -224,6 +224,40 @@ def test_transform_rename_pk(fresh_db):
     )
 
 
+def test_transform_preserves_keyword_literal_defaults(fresh_db):
+    # transform() used to requote keyword-literal defaults (DEFAULT TRUE became
+    # DEFAULT 'TRUE'), so a default insert stored the text 'TRUE' instead of the
+    # integer 1 -- silent value corruption on every rebuilt table.
+    fresh_db.execute(
+        "CREATE TABLE t ("
+        " id INTEGER PRIMARY KEY,"
+        " is_active INTEGER DEFAULT TRUE,"
+        " flag INTEGER DEFAULT FALSE,"
+        " note TEXT DEFAULT NULL"
+        ")"
+    )
+    table = fresh_db["t"]
+    table.insert({"id": 1})
+    before = fresh_db.execute("SELECT is_active, flag, note FROM t").fetchone()
+    assert before == (1, 0, None)
+
+    # Rebuild the table via an unrelated change.
+    table.transform(rename={"note": "note2"})
+
+    # The keyword literals stay unquoted in the schema ...
+    assert "DEFAULT TRUE" in table.schema
+    assert "DEFAULT FALSE" in table.schema
+    assert "DEFAULT NULL" in table.schema
+    assert "'TRUE'" not in table.schema
+
+    # ... and a fresh default insert still yields 1 / 0 / NULL, not strings.
+    table.insert({"id": 2})
+    after = fresh_db.execute(
+        "SELECT is_active, flag, note2 FROM t WHERE id = 2"
+    ).fetchone()
+    assert after == (1, 0, None)
+
+
 def test_transform_not_null(fresh_db):
     dogs = fresh_db["dogs"]
     dogs.insert({"id": 1, "name": "Cleo", "age": "5"}, pk="id")


### PR DESCRIPTION
### The bug

`table.transform()` corrupts `TRUE` / `FALSE` / `NULL` keyword-literal column defaults into string literals, silently changing the value future rows receive.

```python
import sqlite_utils
db = sqlite_utils.Database(memory=True)
db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, is_active INTEGER DEFAULT TRUE)")
db["t"].insert({"id": 1})
db["t"].transform(rename={"id": "pk"})          # any structure-only rebuild
print(db["t"].schema)                            # ... "is_active" INTEGER DEFAULT 'TRUE'
db["t"].insert({})
print(db.execute("SELECT is_active FROM t").fetchall())   # [(1,), ('TRUE',)]  <-- corrupted
```

Before the transform a default insert stored the integer `1`; afterwards it stores the text `'TRUE'`. Same for `FALSE` (→ `'FALSE'` instead of `0`) and `NULL` (→ `'NULL'` instead of null). On an `INTEGER` column the quoted `'TRUE'` isn't numeric, so it's stored as TEXT — a genuine type and value change.

### Cause

`transform()` rebuilds the table by re-emitting each column's `PRAGMA table_info` default through `quote_default_value()`. That method returns the value verbatim when it is already quoted, is a `CURRENT_TIME/DATE/TIMESTAMP` literal, or ends with `)`; otherwise it calls `self.quote()`. The keyword literals `TRUE`, `FALSE` and `NULL` match none of those guards, so they get string-quoted.

### The fix

Return `TRUE` / `FALSE` / `NULL` unquoted, mirroring the existing `CURRENT_*` handling. A populated/numeric/expression default is unaffected.

### Tests

Added `TRUE` / `FALSE` / `true` / `NULL` cases to the `quote_default_value` `EXAMPLES` table, and a functional `test_transform_preserves_keyword_literal_defaults` that creates `DEFAULT TRUE/FALSE/NULL`, rebuilds via `transform()`, and asserts the schema stays unquoted **and** a fresh default insert still yields `1 / 0 / NULL`. All new cases fail on `main` and pass with the fix; the full `test_default_value.py` + `test_transform.py` suites stay green (78 passed); `black`, `flake8` and `mypy` clean.


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--764.org.readthedocs.build/en/764/

<!-- readthedocs-preview sqlite-utils end -->