### PR TITLE
Quality: Built-in name shadowing in `jsonsplit` signature

### DIFF
--- a/sqlite_utils/recipes.py
+++ b/sqlite_utils/recipes.py
@@ -68,9 +68,9 @@ def parsedatetime(
 
 
 def jsonsplit(
-    value: str, delimiter: str = ",", type: Callable[[str], object] = str
+    value: str, delimiter: str = ",", type_: Callable[[str], object] = str
 ) -> str:
     """
     Convert a string like a,b,c into a JSON array ["a", "b", "c"]
     """
-    return json.dumps([type(s.strip()) for s in value.split(delimiter)])
+    return json.dumps([type_(s.strip()) for s in value.split(delimiter)])


### PR DESCRIPTION
## Summary

Quality: Built-in name shadowing in `jsonsplit` signature

## Problem

**Severity**: `Medium` | **File**: `sqlite_utils/recipes.py:L55`

The `jsonsplit` function in `recipes.py` uses `type` as a parameter name, shadowing the Python built-in `type`. This can cause subtle bugs if the built-in is needed within the function scope or in nested calls, and it reduces code clarity for readers.

## Solution

Rename the parameter to `type_` or `value_type` to avoid shadowing the built-in `type`. Update all call sites accordingly.

## Changes

- `sqlite_utils/recipes.py` (modified)

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--780.org.readthedocs.build/en/780/

<!-- readthedocs-preview sqlite-utils end -->