### PR TITLE
Add cross-reference notes between CLI and Python API documentation

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -424,6 +424,9 @@ The ``--functions`` option can be used multiple times to load functions from mul
         from urllib.parse import urlparse
         return urlparse(url).path'
 
+.. note::
+    In Python: :ref:`db.register_function() <python_api_register_function>`
+
 .. _cli_query_extensions:
 
 SQLite extensions
@@ -1024,6 +1027,9 @@ To show more than 10 common values, use ``--common-limit 20``.  To skip the most
 
     sqlite-utils analyze-tables github.db tags --common-limit 20 --no-least
 
+.. note::
+    In Python: :ref:`table.analyze_column() <python_api_analyze_column>`  CLI reference: :ref:`sqlite-utils analyze-tables <cli_ref_analyze_tables>`
+
 .. _cli_analyze_tables_save:
 
 Saving the analyzed table details
@@ -1190,6 +1196,9 @@ You can delete all the existing rows in the table before inserting the new recor
     sqlite-utils insert dogs.db dogs dogs.json --truncate
 
 You can add the ``--analyze`` option to run ``ANALYZE`` against the table after the rows have been inserted.
+
+.. note::
+    In Python: :ref:`table.insert_all() <python_api_bulk_inserts>`  CLI reference: :ref:`sqlite-utils insert <cli_ref_insert>`
 
 .. _cli_inserting_data_binary:
 
@@ -1615,6 +1624,9 @@ To replace a dog with in ID of 2 with a new record, run the following:
     echo '{"id": 2, "name": "Pancakes", "age": 3}' | \
         sqlite-utils insert dogs.db dogs - --pk=id --replace
 
+.. note::
+    In Python: :ref:`table.insert(..., replace=True) <python_api_insert_replace>`  CLI reference: :ref:`sqlite-utils insert <cli_ref_insert>`
+
 .. _cli_upsert:
 
 Upserting data
@@ -1640,6 +1652,9 @@ The command will fail if you reference columns that do not exist on the table. T
 .. note::
     ``upsert`` in sqlite-utils 1.x worked like ``insert ... --replace`` does in 2.x. See `issue #66 <https://github.com/simonw/sqlite-utils/issues/66>`__ for details of this change.
 
+
+.. note::
+    In Python: :ref:`table.upsert() <python_api_upsert>`  CLI reference: :ref:`sqlite-utils upsert <cli_ref_upsert>`
 
 .. _cli_bulk:
 
@@ -1841,6 +1856,9 @@ You can include named parameters in your where clause and populate them using on
         --param query '%cat%'
 
 The ``--dry-run`` option will output a preview of the conversion against the first ten rows, without modifying the database.
+
+.. note::
+    In Python: :ref:`table.convert() <python_api_convert>`  CLI reference: :ref:`sqlite-utils convert <cli_ref_convert>`
 
 .. _cli_convert_import:
 
@@ -2140,6 +2158,9 @@ If a table with the same name already exists, you will get an error. You can cho
 
 You can also pass ``--transform`` to transform the existing table to match the new schema. See :ref:`python_api_explicit_create` in the Python library documentation for details of how this option works.
 
+.. note::
+    In Python: :ref:`table.create() <python_api_explicit_create>`  CLI reference: :ref:`sqlite-utils create-table <cli_ref_create_table>`
+
 .. _cli_renaming_tables:
 
 Renaming a table
@@ -2153,6 +2174,9 @@ Yo ucan rename a table using the ``rename-table`` command:
 
 Pass ``--ignore`` to ignore any errors caused by the table not existing, or the new name already being in use.
 
+.. note::
+    In Python: :ref:`db.rename_table() <python_api_rename_table>`  CLI reference: :ref:`sqlite-utils rename-table <cli_ref_rename_table>`
+
 .. _cli_duplicate_table:
 
 Duplicating tables
@@ -2163,6 +2187,9 @@ The ``duplicate`` command duplicates a table - creating a new table with the sam
 .. code-block:: bash
 
     sqlite-utils duplicate books.db authors authors_copy
+
+.. note::
+    In Python: :ref:`table.duplicate() <python_api_duplicate>`  CLI reference: :ref:`sqlite-utils duplicate <cli_ref_duplicate>`
 
 .. _cli_drop_table:
 
@@ -2176,6 +2203,9 @@ You can drop a table using the ``drop-table`` command:
     sqlite-utils drop-table mydb.db mytable
 
 Use ``--ignore`` to ignore the error if the table does not exist.
+
+.. note::
+    In Python: :ref:`table.drop() <python_api_drop>`  CLI reference: :ref:`sqlite-utils drop-table <cli_ref_drop_table>`
 
 .. _cli_transform_table:
 
@@ -2259,6 +2289,9 @@ If you want to see the SQL that will be executed to make the change without actu
        SELECT "longitude", "latitude", "pk", "name" FROM "roadside_attractions";
     DROP TABLE "roadside_attractions";
     ALTER TABLE "roadside_attractions_new_4033a60276b9" RENAME TO "roadside_attractions";
+
+.. note::
+    In Python: :ref:`table.transform() <python_api_transform>`  CLI reference: :ref:`sqlite-utils transform <cli_ref_transform>`
 
 .. _cli_transform_table_add_primary_key_to_rowid:
 
@@ -2437,6 +2470,9 @@ After running the above, the command ``sqlite-utils schema global.db`` reveals t
     CREATE UNIQUE INDEX "idx_countries_country_name"
         ON "countries" ("country", "name");
 
+.. note::
+    In Python: :ref:`table.extract() <python_api_extract>`  CLI reference: :ref:`sqlite-utils extract <cli_ref_extract>`
+
 .. _cli_create_view:
 
 Creating views
@@ -2458,6 +2494,9 @@ You can create a view using the ``create-view`` command:
 
 Use ``--replace`` to replace an existing view of the same name, and ``--ignore`` to do nothing if a view already exists.
 
+.. note::
+    In Python: :ref:`db.create_view() <python_api_create_view>`  CLI reference: :ref:`sqlite-utils create-view <cli_ref_create_view>`
+
 .. _cli_drop_view:
 
 Dropping views
@@ -2470,6 +2509,9 @@ You can drop a view using the ``drop-view`` command:
     sqlite-utils drop-view myview
 
 Use ``--ignore`` to ignore the error if the view does not exist.
+
+.. note::
+    In Python: :ref:`view.drop() <python_api_drop>`  CLI reference: :ref:`sqlite-utils drop-view <cli_ref_drop_view>`
 
 .. _cli_add_column:
 
@@ -2511,6 +2553,9 @@ You can set a ``NOT NULL DEFAULT 'x'`` constraint on the new column using ``--no
 
     sqlite-utils add-column mydb.db dogs friends_count integer --not-null-default 0
 
+.. note::
+    In Python: :ref:`table.add_column() <python_api_add_column>`  CLI reference: :ref:`sqlite-utils add-column <cli_ref_add_column>`
+
 .. _cli_add_column_alter:
 
 Adding columns automatically on insert/update
@@ -2521,6 +2566,9 @@ You can use the ``--alter`` option to automatically add new columns if the data 
 .. code-block:: bash
 
     sqlite-utils insert dogs.db dogs new-dogs.json --pk=id --alter
+
+.. note::
+    In Python: :ref:`table.insert(..., alter=True) <python_api_add_column_alter>`
 
 .. _cli_add_foreign_key:
 
@@ -2549,6 +2597,9 @@ Add ``--ignore`` to ignore an existing foreign key (as opposed to returning an e
 
 See :ref:`python_api_add_foreign_key` in the Python API documentation for further details, including how the automatic table guessing mechanism works.
 
+.. note::
+    In Python: :ref:`table.add_foreign_key() <python_api_add_foreign_key>`  CLI reference: :ref:`sqlite-utils add-foreign-key <cli_ref_add_foreign_key>`
+
 .. _cli_add_foreign_keys:
 
 Adding multiple foreign keys at once
@@ -2564,6 +2615,9 @@ Adding a foreign key requires a ``VACUUM``. On large databases this can be an ex
 
 When you are using this command each foreign key needs to be defined in full, as four arguments - the table, column, other table and other column.
 
+.. note::
+    In Python: :ref:`db.add_foreign_keys() <python_api_add_foreign_keys>`  CLI reference: :ref:`sqlite-utils add-foreign-keys <cli_ref_add_foreign_keys>`
+
 .. _cli_index_foreign_keys:
 
 Adding indexes for all foreign keys
@@ -2574,6 +2628,9 @@ If you want to ensure that every foreign key column in your database has a corre
 .. code-block:: bash
 
     sqlite-utils index-foreign-keys books.db
+
+.. note::
+    In Python: :ref:`db.index_foreign_keys() <python_api_index_foreign_keys>`  CLI reference: :ref:`sqlite-utils index-foreign-keys <cli_ref_index_foreign_keys>`
 
 .. _cli_defaults_not_null:
 
@@ -2589,6 +2646,9 @@ You can use the ``--not-null`` and ``--default`` options (to both ``insert`` and
         --not-null=name \
         --default age 2 \
         --default score 5
+
+.. note::
+    In Python: :ref:`not_null= and defaults= arguments <python_api_defaults_not_null>`
 
 .. _cli_create_index:
 
@@ -2621,6 +2681,9 @@ If your column names are already prefixed with a hyphen you'll need to manually 
 
 Add the ``--analyze`` option to run ``ANALYZE`` against the index after it has been created.
 
+.. note::
+    In Python: :ref:`table.create_index() <python_api_create_index>`  CLI reference: :ref:`sqlite-utils create-index <cli_ref_create_index>`
+
 .. _cli_drop_index:
 
 Dropping indexes
@@ -2633,6 +2696,9 @@ You can drop an index from an existing table using the ``drop-index`` command:
     sqlite-utils drop-index mydb.db mytable idx_mytable_col1
 
 Use ``--ignore`` to ignore the error if the index does not exist on that table.
+
+.. note::
+    In Python: :ref:`table.drop_index() <python_api_create_index>`  CLI reference: :ref:`sqlite-utils drop-index <cli_ref_drop_index>`
 
 .. _cli_fts:
 
@@ -2686,6 +2752,9 @@ You can rebuild every FTS table by running ``rebuild-fts`` without passing any t
 .. code-block:: bash
 
     sqlite-utils rebuild-fts mydb.db
+
+.. note::
+    In Python: :ref:`table.enable_fts() <python_api_fts_enable>`  CLI reference: :ref:`sqlite-utils enable-fts <cli_ref_enable_fts>`
 
 .. _cli_search:
 
@@ -2743,6 +2812,9 @@ Use the ``--sql`` option to output the SQL that would be executed, rather than r
     order by
         "documents_fts".rank
 
+.. note::
+    In Python: :ref:`table.search() <python_api_fts_search>`  CLI reference: :ref:`sqlite-utils search <cli_ref_search>`
+
 .. _cli_enable_counts:
 
 Enabling cached counts
@@ -2765,6 +2837,9 @@ If the ``_counts`` table ever becomes out-of-sync with the actual table counts y
 .. code-block:: bash
 
     sqlite-utils reset-counts mydb.db
+
+.. note::
+    In Python: :ref:`table.enable_counts() <python_api_cached_table_counts>`  CLI reference: :ref:`sqlite-utils enable-counts <cli_ref_enable_counts>`
 
 .. _cli_analyze:
 
@@ -2789,6 +2864,9 @@ You can run it against specific tables, or against specific named indexes, by pa
 
 You can also run ``ANALYZE`` as part of another command using the ``--analyze`` option. This is supported by the ``create-index``, ``insert`` and ``upsert`` commands.
 
+.. note::
+    In Python: :ref:`db.analyze() <python_api_analyze>`  CLI reference: :ref:`sqlite-utils analyze <cli_ref_analyze>`
+
 .. _cli_vacuum:
 
 Vacuum
@@ -2799,6 +2877,9 @@ You can run VACUUM to optimize your database like so:
 .. code-block:: bash
 
     sqlite-utils vacuum mydb.db
+
+.. note::
+    In Python: :ref:`db.vacuum() <python_api_vacuum>`  CLI reference: :ref:`sqlite-utils vacuum <cli_ref_vacuum>`
 
 .. _cli_optimize:
 
@@ -2823,6 +2904,9 @@ To optimize specific tables rather than every FTS table, pass those tables as ex
 
     sqlite-utils optimize mydb.db table_1 table_2
 
+.. note::
+    In Python: :ref:`table.optimize() <python_api_fts_optimize>`  CLI reference: :ref:`sqlite-utils optimize <cli_ref_optimize>`
+
 .. _cli_wal:
 
 WAL mode
@@ -2842,6 +2926,9 @@ You can disable WAL mode using ``disable-wal``:
 
 Both of these commands accept one or more database files as arguments.
 
+.. note::
+    In Python: :ref:`db.enable_wal() and db.disable_wal() <python_api_wal>`  CLI reference: :ref:`sqlite-utils enable-wal <cli_ref_enable_wal>`
+
 .. _cli_dump:
 
 Dumping the database to SQL
@@ -2856,6 +2943,9 @@ The ``dump`` command outputs a SQL dump of the schema and full contents of the s
     CREATE TABLE ...
     ...
     COMMIT;
+
+.. note::
+    In Python: :ref:`db.iterdump() <python_api_itedump>`  CLI reference: :ref:`sqlite-utils dump <cli_ref_dump>`
 
 .. _cli_load_extension:
 
@@ -2904,6 +2994,9 @@ Eight (case-insensitive) types are allowed:
 * GEOMETRYCOLLECTION
 * GEOMETRY
 
+.. note::
+    In Python: :ref:`table.add_geometry_column() <python_api_gis_add_geometry_column>`  CLI reference: :ref:`sqlite-utils add-geometry-column <cli_ref_add_geometry_column>`
+
 .. _cli_spatialite_indexes:
 
 Adding spatial indexes
@@ -2916,6 +3009,9 @@ Once you have a geometry column, you can speed up bounding box queries by adding
     sqlite-utils create-spatial-index spatial.db locations geometry
 
 See this `SpatiaLite Cookbook recipe <http://www.gaia-gis.it/gaia-sins/spatialite-cookbook-5/cookbook_topics.03.html#topic_Wonderful_RTree_Spatial_Index>`__ for examples of how to use a spatial index.
+
+.. note::
+    In Python: :ref:`table.create_spatial_index() <python_api_gis_create_spatial_index>`  CLI reference: :ref:`sqlite-utils create-spatial-index <cli_ref_create_spatial_index>`
 
 .. _cli_install:
 

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -184,6 +184,9 @@ You can attach an additional database using the ``.attach()`` method, providing 
 
 You can reference tables in the attached database using the alias value you passed to ``db.attach(alias, filepath)`` as a prefix, for example the ``second.table_in_second`` reference in the SQL query above.
 
+.. note::
+    In the CLI: :ref:`sqlite-utils --attach <cli_query_attach>`
+
 .. _python_api_tracing:
 
 Tracing queries
@@ -253,6 +256,9 @@ If a query returns more than one column with the same name - a join between two 
     # {'id': 1, 'id_2': 2, 'id_3': 3}
 
 A suffix that would collide with another column in the query is skipped - ``select 1 as id, 2 as id, 3 as id_2`` returns ``{'id': 1, 'id_3': 2, 'id_2': 3}``. The same renaming is applied by ``table.rows_where()`` and ``table.search()``.
+
+.. note::
+    In the CLI: :ref:`sqlite-utils query <cli_query>`
 
 .. _python_api_execute:
 
@@ -497,6 +503,9 @@ You can also iterate through the table objects themselves using the ``.tables`` 
     >>> db.tables
     [<Table dogs>]
 
+.. note::
+    In the CLI: :ref:`sqlite-utils tables <cli_tables>`
+
 .. _python_api_views:
 
 Listing views
@@ -521,6 +530,9 @@ View objects are similar to Table objects, except that any attempts to insert or
 * ``rows``
 * ``rows_where(where, where_args, order_by, select)``
 * ``drop()``
+
+.. note::
+    In the CLI: :ref:`sqlite-utils views <cli_views>`
 
 .. _python_api_rows:
 
@@ -576,6 +588,9 @@ This method also accepts ``offset=`` and ``limit=`` arguments, for specifying an
     >>> for row in db.table("dogs").rows_where(order_by="age desc", limit=1):
     ...     print(row)
     {'id': 1, 'age': 4, 'name': 'Cleo'}
+
+.. note::
+    In the CLI: :ref:`sqlite-utils rows <cli_rows>`
 
 .. _python_api_rows_count_where:
 
@@ -660,6 +675,9 @@ The ``db.schema`` property returns the full SQL schema for the database as a str
         "id" INTEGER PRIMARY KEY,
         "name" TEXT
     );
+
+.. note::
+    In the CLI: :ref:`sqlite-utils schema <cli_schema>`
 
 .. _python_api_creating_tables:
 
@@ -808,6 +826,9 @@ You can pass ``strict=True`` to create a table in ``STRICT`` mode:
         "id": int,
         "name": str,
     }, strict=True)
+
+.. note::
+    In the CLI: :ref:`sqlite-utils create-table <cli_create_table>`
 
 .. _python_api_compound_primary_keys:
 
@@ -989,6 +1010,9 @@ Here's an example that uses these features:
     # )
 
 
+.. note::
+    In the CLI: :ref:`sqlite-utils insert --not-null and --default <cli_defaults_not_null>`
+
 .. _python_api_rename_table:
 
 Renaming a table
@@ -1006,6 +1030,9 @@ This executes the following SQL:
 
     ALTER TABLE [my_table] RENAME TO [new_name_for_my_table]
 
+.. note::
+    In the CLI: :ref:`sqlite-utils rename-table <cli_renaming_tables>`
+
 .. _python_api_duplicate:
 
 Duplicating tables
@@ -1020,6 +1047,9 @@ The ``table.duplicate()`` method creates a copy of the table, copying both the t
 The new ``authors_copy`` table will now contain a duplicate copy of the data from ``authors``.
 
 This method raises ``sqlite_utils.db.NoTable`` if the table does not exist.
+
+.. note::
+    In the CLI: :ref:`sqlite-utils duplicate <cli_duplicate_table>`
 
 .. _python_api_bulk_inserts:
 
@@ -1062,6 +1092,9 @@ You can skip inserting any records that have a primary key that already exists u
 You can delete all the existing rows in the table before inserting the new records using ``truncate=True``. This is useful if you want to replace the data in the table.
 
 Pass ``analyze=True`` to run ``ANALYZE`` against the table after inserting the new records.
+
+.. note::
+    In the CLI: :ref:`sqlite-utils insert <cli_inserting_data>`
 
 .. _python_api_insert_lists:
 
@@ -1139,6 +1172,9 @@ To replace any existing records that have a matching primary key, use the ``repl
 
 .. note::
     Prior to sqlite-utils 2.0 the ``.upsert()`` and ``.upsert_all()`` methods worked the same way as ``.insert(replace=True)`` does today. See :ref:`python_api_upsert` for the new behaviour of those methods introduced in 2.0.
+
+.. note::
+    In the CLI: :ref:`sqlite-utils insert --replace <cli_insert_replace>`
 
 .. _python_api_update:
 
@@ -1224,6 +1260,9 @@ Every record passed to ``upsert()`` or ``upsert_all()`` must include a value for
 
 .. note::
     ``.upsert()`` and ``.upsert_all()`` in sqlite-utils 1.x worked like ``.insert(..., replace=True)`` and ``.insert_all(..., replace=True)`` do in 2.x. See `issue #66 <https://github.com/simonw/sqlite-utils/issues/66>`__ for details of this change.
+
+.. note::
+    In the CLI: :ref:`sqlite-utils upsert <cli_upsert>`
 
 .. _python_api_old_upsert:
 
@@ -1576,6 +1615,9 @@ You can set a ``NOT NULL DEFAULT 'x'`` constraint on the new column using ``not_
 
     db.table("dogs").add_column("friends_count", int, not_null_default=0)
 
+.. note::
+    In the CLI: :ref:`sqlite-utils add-column <cli_add_column>`
+
 .. _python_api_add_column_alter:
 
 Adding columns automatically on insert/update
@@ -1598,6 +1640,9 @@ You can insert or update data that includes new columns and have the table autom
     # This works too:
     new_table = db.table("new_table", alter=True)
     new_table.insert({"name": "Gareth", "age": 32, "shoe_size": 11})
+
+.. note::
+    In the CLI: :ref:`sqlite-utils insert --alter <cli_add_column_alter>`
 
 .. _python_api_add_foreign_key:
 
@@ -1657,6 +1702,9 @@ Use ``on_delete=`` and ``on_update=`` to specify ``ON DELETE`` and ``ON UPDATE``
 
 This creates a foreign key with an ``ON DELETE CASCADE`` clause, so deleting an author will also delete their books (provided foreign key enforcement is enabled with ``PRAGMA foreign_keys = ON``). Valid actions are ``"SET NULL"``, ``"SET DEFAULT"``, ``"CASCADE"``, ``"RESTRICT"`` and the default ``"NO ACTION"``.
 
+.. note::
+    In the CLI: :ref:`sqlite-utils add-foreign-key <cli_add_foreign_key>`
+
 .. _python_api_add_foreign_keys:
 
 Adding multiple foreign key constraints at once
@@ -1677,6 +1725,9 @@ This method runs the same checks as ``.add_foreign_keys()`` and will raise ``sql
 
 Foreign keys that already exist are silently skipped, so repeated calls are idempotent - but only if they match exactly. Requesting a foreign key that exists with different ``ON DELETE``/``ON UPDATE`` actions raises ``AlterError``: use ``table.transform()`` to change the actions of an existing foreign key.
 
+.. note::
+    In the CLI: :ref:`sqlite-utils add-foreign-keys <cli_add_foreign_keys>`
+
 .. _python_api_index_foreign_keys:
 
 Adding indexes for all foreign keys
@@ -1689,6 +1740,9 @@ If you want to ensure that every foreign key column in your database has a corre
     db.index_foreign_keys()
 
 Compound foreign keys get a single composite index across their columns.
+
+.. note::
+    In the CLI: :ref:`sqlite-utils index-foreign-keys <cli_index_foreign_keys>`
 
 .. _python_api_drop:
 
@@ -1710,6 +1764,9 @@ Pass ``ignore=True`` if you want to ignore the error caused by the table or view
 .. code-block:: python
 
     db.table("my_table").drop(ignore=True)
+
+.. note::
+    In the CLI: :ref:`sqlite-utils drop-table <cli_drop_table>` and :ref:`sqlite-utils drop-view <cli_drop_view>`
 
 .. _python_api_transform:
 
@@ -1738,6 +1795,9 @@ To keep the original table around instead of dropping it, pass the ``keep_table=
     table.transform(types={"age": int}, keep_table="original_table")
 
 This method raises a ``sqlite_utils.db.TransformError`` exception if the table cannot be transformed, usually because there are existing constraints or indexes that are incompatible with modifications to the columns.
+
+.. note::
+    In the CLI: :ref:`sqlite-utils transform <cli_transform_table>`
 
 .. _python_api_transform_alter_column_types:
 
@@ -2094,6 +2154,9 @@ This produces a lookup table like so:
 
 Rows where every extracted column is ``null`` are not extracted: no record is created for them in the lookup table and their foreign key column is left as ``null``. When extracting multiple columns, rows where at least one of the extracted columns has a value will be extracted as usual.
 
+.. note::
+    In the CLI: :ref:`sqlite-utils extract <cli_extract>`
+
 .. _python_api_hash:
 
 Setting an ID based on the hash of the row contents
@@ -2154,6 +2217,9 @@ You can pass ``ignore=True`` to silently ignore an existing view and do nothing,
     db.create_view("good_dogs", """
         select * from dogs where is_good_dog = 1
     """, replace=True)
+
+.. note::
+    In the CLI: :ref:`sqlite-utils create-view <cli_create_view>`
 
 Storing JSON
 ============
@@ -2272,6 +2338,9 @@ If you are using ``pysqlite3`` the underlying method may be missing. If you inst
 .. code-block:: bash
 
     pip install sqlite-dump
+
+.. note::
+    In the CLI: :ref:`sqlite-utils dump <cli_dump>`
 
 .. _python_api_introspection:
 
@@ -2472,6 +2541,9 @@ The ``.indexes`` property returns all indexes created for a table, as a list of 
      Index(seq=4, name='"Street_Tree_List_qCaretaker"', unique=0, origin='c', partial=0, columns=['qCaretaker']),
      Index(seq=5, name='"Street_Tree_List_PlantType"', unique=0, origin='c', partial=0, columns=['PlantType'])]
 
+.. note::
+    In the CLI: :ref:`sqlite-utils indexes <cli_indexes>`
+
 .. _python_api_introspection_xindexes:
 
 .xindexes
@@ -2514,6 +2586,9 @@ The ``.triggers`` property lists database triggers. It can be used on both datab
      Trigger(name='authors_au', table='authors', sql="CREATE TRIGGER [authors_au] AFTER UPDATE")]
     >>> db.triggers
     ... similar output to db.table("authors").triggers
+
+.. note::
+    In the CLI: :ref:`sqlite-utils triggers <cli_triggers>`
 
 .. _python_api_introspection_triggers_dict:
 
@@ -2663,6 +2738,9 @@ To remove the FTS tables and triggers you created, use the ``disable_fts()`` tab
 
     db.table("dogs").disable_fts()
 
+.. note::
+    In the CLI: :ref:`sqlite-utils enable-fts <cli_fts>`
+
 .. _python_api_quote_fts:
 
 Quoting characters for use in search
@@ -2726,6 +2804,9 @@ To return just the title and published columns for three matches for ``"dog"`` w
         columns=["title", "published"]
     ):
         print(article)
+
+.. note::
+    In the CLI: :ref:`sqlite-utils search <cli_search>`
 
 .. _python_api_fts_search_sql:
 
@@ -2811,6 +2892,9 @@ This runs the following SQL::
 
     INSERT INTO dogs_fts (dogs_fts) VALUES ("rebuild");
 
+.. note::
+    In the CLI: :ref:`sqlite-utils rebuild-fts <cli_fts>`
+
 .. _python_api_fts_optimize:
 
 Optimizing a full-text search table
@@ -2825,6 +2909,9 @@ Once you have populated a FTS table you can optimize it to dramatically reduce i
 This runs the following SQL::
 
     INSERT INTO dogs_fts (dogs_fts) VALUES ("optimize");
+
+.. note::
+    In the CLI: :ref:`sqlite-utils optimize <cli_optimize>`
 
 .. _python_api_cached_table_counts:
 
@@ -2888,6 +2975,9 @@ If the ``_counts`` table ever becomes out-of-sync with the actual table counts y
 
     db.reset_counts()
 
+.. note::
+    In the CLI: :ref:`sqlite-utils enable-counts <cli_enable_counts>`
+
 .. _python_api_create_index:
 
 Creating indexes
@@ -2939,6 +3029,9 @@ You can drop an index from a table using ``.drop_index(index_name)``:
 
 Use ``ignore=True`` to ignore the error if the index does not exist.
 
+.. note::
+    In the CLI: :ref:`sqlite-utils create-index <cli_create_index>` and :ref:`sqlite-utils drop-index <cli_drop_index>`
+
 .. _python_api_analyze:
 
 Optimizing index usage with ANALYZE
@@ -2966,6 +3059,9 @@ To run against all indexes attached to a specific table, you can either pass the
 
     db.table("dogs").analyze()
 
+.. note::
+    In the CLI: :ref:`sqlite-utils analyze <cli_analyze>`
+
 .. _python_api_vacuum:
 
 Vacuum
@@ -2976,6 +3072,9 @@ You can optimize your database by running VACUUM against it like so:
 .. code-block:: python
 
     Database("my_database.db").vacuum()
+
+.. note::
+    In the CLI: :ref:`sqlite-utils vacuum <cli_vacuum>`
 
 .. _python_api_wal:
 
@@ -3003,6 +3102,9 @@ You can check the current journal mode for a database using the ``journal_mode``
     journal_mode = Database("my_database.db").journal_mode
 
 This will usually be ``wal`` or ``delete`` (meaning WAL is disabled), but can have other values - see the `PRAGMA journal_mode <https://www.sqlite.org/pragma.html#pragma_journal_mode>`__ documentation.
+
+.. note::
+    In the CLI: :ref:`sqlite-utils enable-wal and disable-wal <cli_wal>`
 
 .. _python_api_suggest_column_types:
 
@@ -3144,6 +3246,9 @@ You can cause ``sqlite3`` to return more useful errors, including the traceback 
 
     sqlite3.enable_callback_tracebacks(True)
 
+.. note::
+    In the CLI: :ref:`sqlite-utils query --functions <cli_query_functions>`
+
 .. _python_api_quote:
 
 Quoting strings for use in SQL
@@ -3276,6 +3381,9 @@ Initialize SpatiaLite
 .. automethod:: sqlite_utils.db.Database.init_spatialite
    :noindex:
 
+.. note::
+    In the CLI: :ref:`sqlite-utils create-database --init-spatialite <cli_create_database>`
+
 .. _python_api_gis_find_spatialite:
 
 Finding SpatiaLite
@@ -3291,6 +3399,9 @@ Adding geometry columns
 .. automethod:: sqlite_utils.db.Table.add_geometry_column
    :noindex:
 
+.. note::
+    In the CLI: :ref:`sqlite-utils add-geometry-column <cli_spatialite>`
+
 .. _python_api_gis_create_spatial_index:
 
 Creating a spatial index
@@ -3298,3 +3409,6 @@ Creating a spatial index
 
 .. automethod:: sqlite_utils.db.Table.create_spatial_index
    :noindex:
+
+.. note::
+    In the CLI: :ref:`sqlite-utils create-spatial-index <cli_spatialite_indexes>`


### PR DESCRIPTION
> Take a look at the CLI documentation, and how it occasionally linked to the corresponding python feature - review if there are opportunities to add more links like that, and also to add reverse links back from Python to CLI

The CLI documentation had a handful of sections with notes linking to the
equivalent Python API feature. Extend that pattern to every CLI section
with a Python equivalent, and add matching 'In the CLI:' notes to the
Python API documentation linking back to the corresponding CLI command.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WrZcTpmBvCq1HqPDweDjVT

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--791.org.readthedocs.build/en/791/

<!-- readthedocs-preview sqlite-utils end -->