### PR TITLE
Fix VACUUM with an open transaction

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1897,6 +1897,7 @@ class Database:
 
     def vacuum(self) -> None:
         "Run a SQLite ``VACUUM`` against the database."
+        self.commit()
         self.execute("VACUUM;")
 
     def analyze(self, name: Optional[str] = None) -> None:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1170,6 +1170,17 @@ def test_vacuum(fresh_db):
     fresh_db.vacuum()
 
 
+def test_vacuum_commits_open_transaction(fresh_db):
+    fresh_db["data"].insert({"foo": "foo"})
+    fresh_db.begin()
+    fresh_db.execute("insert into data (foo) values ('bar')")
+
+    fresh_db.vacuum()
+
+    assert not fresh_db.conn.in_transaction
+    assert [row["foo"] for row in fresh_db["data"].rows] == ["foo", "bar"]
+
+
 def test_works_with_pathlib_path(tmpdir):
     path = pathlib.Path(tmpdir / "test.db")
     db = Database(path)


### PR DESCRIPTION
`Database.vacuum()` currently passes `VACUUM` to SQLite while a caller-owned transaction may still be open, which raises `OperationalError`. Commit that transaction first so the documented maintenance method can run; the regression test verifies both the commit and preserved rows.

Fixes #479

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--798.org.readthedocs.build/en/798/

<!-- readthedocs-preview sqlite-utils end -->