### PR TITLE
Fix _decode_default_value returning float for negative integer defaults

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -5214,7 +5214,7 @@ def _decode_default_value(value: str) -> object:
     if value.startswith("'") and value.endswith("'"):
         # It's a string
         return value[1:-1]
-    if value.isdigit():
+    if re.fullmatch(r"-?\d+", value):
         # It's an integer
         return int(value)
     if value.startswith("X'") and value.endswith("'"):

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -309,6 +309,7 @@ def test_table_strict(fresh_db, create_table, expected_strict):
     "value",
     (
         1,
+        -5,
         1.3,
         "foo",
         True,


### PR DESCRIPTION
Python's `str.isdigit()` returns `False` for strings like `"-5"`, so a column declared `DEFAULT -5` in SQLite had its default decoded as `-5.0` (float) instead of `-5` (int) by `_decode_default_value`. The fix switches to `re.fullmatch(r"-?\d+", value)` to correctly handle negative integer strings.

A new parametrize case (`-5`) is added to `test_table_default_values` which reproduced the bug before the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_016N3BTVKr1wrKv6CJUaADTW)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--799.org.readthedocs.build/en/799/

<!-- readthedocs-preview sqlite-utils end -->