### PR TITLE
Catch runtime exceptions from --code, not just SyntaxError

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -3800,7 +3800,7 @@ def _rows_from_code(code):
     namespace = {}
     try:
         exec(code, namespace)
-    except SyntaxError as ex:
+    except Exception as ex:
         raise click.ClickException("Error in --code: {}".format(ex))
     rows = namespace.get("rows")
     if callable(rows):

--- a/tests/test_cli_insert.py
+++ b/tests/test_cli_insert.py
@@ -880,6 +880,17 @@ def test_insert_code_syntax_error(tmpdir):
     assert "Error in --code" in result.output
 
 
+def test_insert_code_runtime_error(tmpdir):
+    db_path = str(tmpdir / "dogs.db")
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "creatures", "--code", 'raise ValueError("bad data")'],
+    )
+    assert result.exit_code == 1
+    assert "Error in --code" in result.output
+    assert "bad data" in result.output
+
+
 def test_insert_code_file_not_found(tmpdir):
     db_path = str(tmpdir / "dogs.db")
     result = CliRunner().invoke(


### PR DESCRIPTION
When user-supplied --code raises a runtime exception such as ValueError or NameError, _rows_from_code() previously only caught SyntaxError, so the exception propagated silently and the user saw an empty output with exit code 1 and no indication of what went wrong. This changes the except clause to catch Exception so all errors produce the same clean "Error in --code: <message>" message that SyntaxError already produced, and adds a regression test covering the ValueError case.

---
_Generated by [Claude Code](https://claude.ai/code/session_019bFwrH9ZknFMcVEZvCV1h6)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--803.org.readthedocs.build/en/803/

<!-- readthedocs-preview sqlite-utils end -->