### PR TITLE
transform: coerce empty strings to NULL when converting TEXT columns to numeric types

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Unreleased
 - ``sqlite-utils convert --dry-run`` now works for table and column names containing closing square brackets. (:issue:`829`)
 - ``table.indexes`` and ``table.xindexes`` now work for table, index and column names containing double quotes. This also fixes ``table.transform()`` for tables with those identifiers. Thanks, `nyxst4ck <https://github.com/nyxst4ck>`__. (:issue:`824`, `#825 <https://github.com/simonw/sqlite-utils/pull/825>`__)
 - Improved type annotations throughout the package and added Pyright regression checks to CI. (:issue:`833`)
+- Changing a ``TEXT`` column to ``INTEGER``, ``FLOAT`` or ``REAL`` using ``table.transform()`` or ``sqlite-utils transform`` now converts exact empty strings to ``NULL``. Previously they remained empty strings in the numeric column. Thanks, `ikatyal2110 <https://github.com/ikatyal2110>`__. (:issue:`488`, `#805 <https://github.com/simonw/sqlite-utils/pull/805>`__)
 
 .. _v3_39_1:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2236,7 +2236,7 @@ The ``transform`` command allows you to apply complex transformations to a table
 Every option for this table (with the exception of ``--pk-none``) can be specified multiple times. The options are as follows:
 
 ``--type column-name new-type``
-    Change the type of the specified column. Valid types are ``integer``, ``text``, ``float``, ``real``, ``blob`` and ``any``.
+    Change the type of the specified column. Valid types are ``integer``, ``text``, ``float``, ``real``, ``blob`` and ``any``. Changing a ``TEXT`` column to ``INTEGER``, ``FLOAT`` or ``REAL`` converts exact empty-string values to ``NULL``.
 
 ``--drop column-name``
     Drop the specified column.

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -1826,6 +1826,8 @@ To alter the type of a column, use the ``types=`` argument:
     # Convert the 'age' column to an integer, and 'weight' to a float
     table.transform(types={"age": int, "weight": float})
 
+When a ``TEXT`` column is changed to ``INTEGER``, ``FLOAT`` or ``REAL``, exact empty-string values are stored as ``NULL``. Other values, including whitespace-only strings, are copied normally.
+
 See :ref:`python_api_add_column` for a list of available types.
 
 .. _python_api_transform_strict:

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2856,6 +2856,19 @@ class Table(Queryable):
             ).strip()
         )
 
+        # Columns being changed from TEXT to a numeric type: coerce empty strings to NULL
+        _numeric_sql_types = {"INTEGER", "REAL", "FLOAT", "NUMERIC"}
+        text_to_numeric_cols = {
+            col_name
+            for col_name, new_type in types.items()
+            if existing_columns.get(col_name) == str
+            and COLUMN_TYPE_MAPPING.get(
+                new_type,
+                new_type.upper() if isinstance(new_type, str) else "",
+            )
+            in _numeric_sql_types
+        }
+
         # Copy across data, respecting any renamed columns
         new_cols = []
         old_cols = []
@@ -2866,10 +2879,16 @@ class Table(Queryable):
         if "rowid" not in new_cols:
             new_cols.insert(0, "rowid")
             old_cols.insert(0, "rowid")
+
+        def _copy_expr(col):
+            if col in text_to_numeric_cols:
+                return "NULLIF({}, '')".format(quote_identifier(col))
+            return quote_identifier(col)
+
         copy_sql = "INSERT INTO {} ({new_cols})\n   SELECT {old_cols} FROM {};".format(
             quote_identifier(new_table_name),
             quote_identifier(self.name),
-            old_cols=", ".join(quote_identifier(col) for col in old_cols),
+            old_cols=", ".join(_copy_expr(col) for col in old_cols),
             new_cols=", ".join(quote_identifier(col) for col in new_cols),
         )
         sqls.append(copy_sql)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -23,7 +23,7 @@ import pytest
             {"types": {"age": int}},
             [
                 'CREATE TABLE "dogs_new_suffix" (\n   "id" INTEGER PRIMARY KEY,\n   "name" TEXT,\n   "age" INTEGER\n);',
-                'INSERT INTO "dogs_new_suffix" ("rowid", "id", "name", "age")\n   SELECT "rowid", "id", "name", "age" FROM "dogs";',
+                'INSERT INTO "dogs_new_suffix" ("rowid", "id", "name", "age")\n   SELECT "rowid", "id", "name", NULLIF("age", \'\') FROM "dogs";',
                 'DROP TABLE "dogs";',
                 'ALTER TABLE "dogs_new_suffix" RENAME TO "dogs";',
             ],
@@ -53,7 +53,7 @@ import pytest
             {"types": {"age": int}, "rename": {"age": "dog_age"}},
             [
                 'CREATE TABLE "dogs_new_suffix" (\n   "id" INTEGER PRIMARY KEY,\n   "name" TEXT,\n   "dog_age" INTEGER\n);',
-                'INSERT INTO "dogs_new_suffix" ("rowid", "id", "name", "dog_age")\n   SELECT "rowid", "id", "name", "age" FROM "dogs";',
+                'INSERT INTO "dogs_new_suffix" ("rowid", "id", "name", "dog_age")\n   SELECT "rowid", "id", "name", NULLIF("age", \'\') FROM "dogs";',
                 'DROP TABLE "dogs";',
                 'ALTER TABLE "dogs_new_suffix" RENAME TO "dogs";',
             ],
@@ -146,7 +146,7 @@ def test_transform_sql_table_with_primary_key(
             {"types": {"age": int}},
             [
                 'CREATE TABLE "dogs_new_suffix" (\n   "id" INTEGER,\n   "name" TEXT,\n   "age" INTEGER\n);',
-                'INSERT INTO "dogs_new_suffix" ("rowid", "id", "name", "age")\n   SELECT "rowid", "id", "name", "age" FROM "dogs";',
+                'INSERT INTO "dogs_new_suffix" ("rowid", "id", "name", "age")\n   SELECT "rowid", "id", "name", NULLIF("age", \'\') FROM "dogs";',
                 'DROP TABLE "dogs";',
                 'ALTER TABLE "dogs_new_suffix" RENAME TO "dogs";',
             ],
@@ -904,3 +904,20 @@ def test_transform_with_unique_constraint_implicit_index(fresh_db):
         "You must manually drop this index prior to running this transformation and manually recreate the new index after running this transformation."
         in str(excinfo.value)
     )
+
+
+@pytest.mark.parametrize("new_type", [int, float, "integer", "float", "REAL"])
+def test_transform_empty_string_to_null_for_numeric_types(fresh_db, new_type):
+    # Empty strings in TEXT columns should become NULL when transforming to numeric types
+    fresh_db["test"].insert_all(
+        [
+            {"id": 1, "value": "42"},
+            {"id": 2, "value": ""},
+            {"id": 3, "value": None},
+        ]
+    )
+    fresh_db["test"].transform(types={"value": new_type})
+    rows = {r["id"]: r["value"] for r in fresh_db["test"].rows}
+    assert rows[1] in (42, 42.0)
+    assert rows[2] is None
+    assert rows[3] is None

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1053,21 +1053,34 @@ def test_transform_with_unique_constraint_implicit_index(fresh_db):
     )
 
 
-@pytest.mark.parametrize("new_type", [int, float, "integer", "float", "REAL"])
-def test_transform_empty_string_to_null_for_numeric_types(fresh_db, new_type):
-    # Empty strings in TEXT columns should become NULL when transforming to numeric types
+@pytest.mark.parametrize(
+    "new_type,expected_value,expected_type",
+    [
+        (int, 42, int),
+        (float, 42.0, float),
+        ("integer", 42, int),
+        ("float", 42.0, float),
+        ("REAL", 42.0, float),
+    ],
+)
+def test_transform_empty_string_to_null_for_numeric_types(
+    fresh_db, new_type, expected_value, expected_type
+):
     fresh_db["test"].insert_all(
         [
             {"id": 1, "value": "42"},
             {"id": 2, "value": ""},
             {"id": 3, "value": None},
+            {"id": 4, "value": " "},
         ]
     )
     fresh_db["test"].transform(types={"value": new_type})
     rows = {r["id"]: r["value"] for r in fresh_db["test"].rows}
-    assert rows[1] in (42, 42.0)
+    assert rows[1] == expected_value
+    assert type(rows[1]) is expected_type
     assert rows[2] is None
     assert rows[3] is None
+    assert rows[4] == " "
 
 
 def test_transform_preserves_view(fresh_db):


### PR DESCRIPTION
When `.transform()` copies data from a TEXT column into a newly-typed INTEGER, FLOAT, or REAL column, empty string values (`""`) are now converted to `NULL` via `NULLIF(col, '')` in the `INSERT … SELECT` statement, instead of being stored as empty strings in the numeric column. Non-empty strings that represent valid numbers continue to be coerced by SQLite as before, and `NULL` values are preserved unchanged. Fixes:
- #488

---
_Generated by [Claude Code](https://claude.ai/code/session_011KHJuenHnLSXG4p8DiYepi)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--805.org.readthedocs.build/en/805/

<!-- readthedocs-preview sqlite-utils end -->