### PR TITLE
fix: allow recipes.jsonsplit to pass through NULL values

### DIFF
--- a/sqlite_utils/recipes.py
+++ b/sqlite_utils/recipes.py
@@ -68,9 +68,11 @@ def parsedatetime(
 
 
 def jsonsplit(
-    value: str, delimiter: str = ",", type: Callable[[str], object] = str
-) -> str:
+    value: Optional[str], delimiter: str = ",", type: Callable[[str], object] = str
+) -> Optional[str]:
     """
     Convert a string like a,b,c into a JSON array ["a", "b", "c"]
     """
+    if value is None:
+        return value
     return json.dumps([type(s.strip()) for s in value.split(delimiter)])

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -101,6 +101,7 @@ def test_jsonsplit(fresh_db, delimiter):
         [
             {"id": 1, "tags": (delimiter or ",").join(["foo", "bar"])},
             {"id": 2, "tags": (delimiter or ",").join(["bar", "baz"])},
+            {"id": 3, "tags": None},
         ],
         pk="id",
     )
@@ -116,6 +117,7 @@ def test_jsonsplit(fresh_db, delimiter):
     assert list(fresh_db["example"].rows) == [
         {"id": 1, "tags": '["foo", "bar"]'},
         {"id": 2, "tags": '["bar", "baz"]'},
+        {"id": 3, "tags": None},
     ]
 
 


### PR DESCRIPTION
recipes.jsonsplit hits AttributeError when NULL/None value via Table.convert. This PR fixes the regression with a focused test covering the case.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--806.org.readthedocs.build/en/806/

<!-- readthedocs-preview sqlite-utils end -->
