### PR TITLE
Fix TypeTracker inferring wrong type for CSV columns containing only empty strings

### DIFF
--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -490,7 +490,7 @@ class ValueTracker:
         return "text"
 
     def evaluate(self, value: object) -> None:
-        if not value or not self.couldbe:
+        if value is None or not self.couldbe:
             return
         not_these: List[str] = []
         for name, test in self.couldbe.items():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from sqlite_utils import utils
+from sqlite_utils.utils import TypeTracker
 import csv
 import io
 import pytest
@@ -71,6 +72,23 @@ def test_maximize_csv_field_size_limit():
     assert len(rows_list2) == 1
     assert rows_list2[0]["id"] == "1"
     assert rows_list2[0]["text"] == long_value
+
+
+@pytest.mark.parametrize(
+    "rows,expected_types",
+    [
+        ([{"a": ""}], {"a": "text"}),
+        ([{"a": ""}, {"a": ""}], {"a": "text"}),
+        ([{"a": "1"}, {"a": ""}], {"a": "text"}),
+        ([{"a": "0"}], {"a": "integer"}),
+        ([{"a": "1"}], {"a": "integer"}),
+        ([{"a": None}], {"a": "integer"}),
+    ],
+)
+def test_type_tracker_empty_strings(rows, expected_types):
+    tracker = TypeTracker()
+    list(tracker.wrap(iter(rows)))
+    assert tracker.types == expected_types
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
ValueTracker.evaluate() used `if not value` to skip None, but this also skipped empty strings (`""`), causing a CSV column whose every row is blank to be typed as INTEGER (the initial default) rather than TEXT. The fix replaces the falsy check with an explicit `if value is None` so only actual NULL values are skipped and empty strings are passed through the type tests, which correctly eliminate integer and float as candidates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnsjqzUor3v7fYAGYVU6FA)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--807.org.readthedocs.build/en/807/

<!-- readthedocs-preview sqlite-utils end -->