### PR TITLE
Fix rows_from_file() crash on empty or whitespace-only input

### DIFF
--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -379,6 +379,8 @@ def rows_from_file(
             raise TypeError(
                 "rows_from_file() requires a file-like object that supports peek(), such as io.BytesIO"
             )
+        if not first_bytes:
+            return iter([]), Format.CSV
         if first_bytes.startswith(b"[") or first_bytes.startswith(b"{"):
             # TODO: Detect newline-JSON
             return rows_from_file(buffered, format=Format.JSON)

--- a/tests/test_rows_from_file.py
+++ b/tests/test_rows_from_file.py
@@ -52,3 +52,10 @@ def test_rows_from_file_error_on_string_io():
     assert ex.value.args == (
         "rows_from_file() requires a file-like object that supports peek(), such as io.BytesIO",
     )
+
+
+@pytest.mark.parametrize("content", [b"", b"   \n\n  "])
+def test_rows_from_file_empty_file(content):
+    rows, fmt = rows_from_file(BytesIO(content))
+    assert list(rows) == []
+    assert fmt == Format.CSV


### PR DESCRIPTION
When `rows_from_file()` is called without an explicit format on an empty or whitespace-only file, the auto-detect path calls `csv.Sniffer().sniff("")` which raises `csv.Error: Could not determine delimiter`. The fix adds an early return of an empty iterator when the peeked bytes are empty after stripping, and a regression test covers both the empty-file and whitespace-only cases. Fixes #808