### PR TITLE
Fix _decode_default_value to unescape doubled single quotes in string defaults

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -5212,8 +5212,8 @@ def resolve_extracts(
 
 def _decode_default_value(value: str) -> object:
     if value.startswith("'") and value.endswith("'"):
-        # It's a string
-        return value[1:-1]
+        # It's a string; unescape doubled single quotes
+        return value[1:-1].replace("''", "'")
     if value.isdigit():
         # It's an integer
         return int(value)

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -311,6 +311,7 @@ def test_table_strict(fresh_db, create_table, expected_strict):
         1,
         1.3,
         "foo",
+        "O'Brien",
         True,
         b"binary",
     ),
@@ -321,6 +322,16 @@ def test_table_default_values(fresh_db, value):
     )
     default_values = fresh_db["default_values"].default_values
     assert default_values == {"value": value}
+
+
+def test_table_default_values_escaped_quotes(fresh_db):
+    # SQLite stores string defaults with single quotes doubled, so
+    # introspection needs to unescape them again
+    fresh_db.execute(
+        "create table t (id integer primary key, name text default 'O''Brien')"
+    )
+    assert "default 'O''Brien'" in fresh_db["t"].schema
+    assert fresh_db["t"].default_values == {"name": "O'Brien"}
 
 
 def test_pks_use_primary_key_declaration_order(fresh_db):


### PR DESCRIPTION
SQLite stores string defaults with single quotes doubled (e.g. `DEFAULT 'O''Brien'` is stored as `'O''Brien'` in `sqlite_master`). The `_decode_default_value` function stripped the outer quotes correctly but never unescaped `''` back to `'`, so `table.default_values` returned the raw escaped form instead of the actual string value. The fix adds `.replace("''", "'")` after stripping the outer quotes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNimtyhwsuZ4aXGDLardEM)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--811.org.readthedocs.build/en/811/

<!-- readthedocs-preview sqlite-utils end -->