### PR TITLE
Fix rows_where() crash when offset is given without limit

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2003,6 +2003,8 @@ class Queryable:
         if limit is not None:
             sql += f" limit {limit}"
         if offset is not None:
+            if limit is None:
+                sql += " limit -1"
             sql += f" offset {offset}"
         cursor = self.db.execute(sql, where_args or [])
         columns = dedupe_keys(c[0] for c in cursor.description)
@@ -3594,6 +3596,8 @@ class Table(Queryable):
         if limit is not None:
             limit_offset += f" limit {limit}"
         if offset is not None:
+            if limit is None:
+                limit_offset += " limit -1"
             limit_offset += f" offset {offset}"
         return sql.format(
             dbtable=quote_identifier(self.name),

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -70,6 +70,13 @@ def test_rows_where_offset_limit(fresh_db, offset, limit, expected):
     ]
 
 
+def test_rows_where_offset_without_limit(fresh_db):
+    table = fresh_db["rows"]
+    table.insert_all([{"id": id} for id in range(1, 6)], pk="id")
+    ids = [r["id"] for r in table.rows_where(offset=2, order_by="id")]
+    assert ids == [3, 4, 5]
+
+
 def test_pks_and_rows_where_rowid(fresh_db):
     table = fresh_db["rowid_table"]
     table.insert_all({"number": i + 10} for i in range(3))


### PR DESCRIPTION
SQLite requires a LIMIT clause before OFFSET; without one, `rows_where(offset=N)` generates `SELECT … OFFSET N` which raises `OperationalError: near "N": syntax error`. The fix emits `LIMIT -1` automatically when offset is set but limit is not, which SQLite treats as "no upper bound". The same pattern is fixed in `search_sql()`. A regression test is added. Fixes #816

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZWbR3mvrRvcHsm5PWknZz)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--817.org.readthedocs.build/en/817/

<!-- readthedocs-preview sqlite-utils end -->