### PR TITLE
Fix KeyError when passing an unrecognized string type to create_table or add_column

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -1480,7 +1480,9 @@ class Database:
                 column_extras.append(
                     f"REFERENCES {quote_identifier(fk.other_table)}({quote_identifier(cast(str, fk.other_column))}){_fk_actions_sql(fk)}"
                 )
-            column_type_str = COLUMN_TYPE_MAPPING[column_type]
+            column_type_str = COLUMN_TYPE_MAPPING.get(column_type) or (
+                column_type if isinstance(column_type, str) else COLUMN_TYPE_MAPPING[column_type]
+            )
             # Special case for strict tables to map FLOAT to REAL
             # Refs https://github.com/simonw/sqlite-utils/issues/644
             if strict and column_type_str == "FLOAT":
@@ -3121,7 +3123,9 @@ class Table(Queryable):
         sql = "ALTER TABLE {} ADD COLUMN {} {col_type}{not_null_default};".format(
             quote_identifier(self.name),
             quote_identifier(col_name),
-            col_type=fk_col_type or COLUMN_TYPE_MAPPING[col_type],
+            col_type=fk_col_type or COLUMN_TYPE_MAPPING.get(col_type) or (
+                col_type if isinstance(col_type, str) else COLUMN_TYPE_MAPPING[col_type]
+            ),
             not_null_default=(" " + not_null_sql) if not_null_sql else "",
         )
         self.db.execute(sql)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -110,6 +110,13 @@ def test_create_table_with_defaults(fresh_db):
     ) == table.schema
 
 
+def test_create_table_with_unknown_string_type(fresh_db):
+    table = fresh_db.create_table("t", {"id": int, "value": "NUMERIC"}, pk="id")
+    assert table.schema == 'CREATE TABLE "t" (\n   "id" INTEGER PRIMARY KEY,\n   "value" NUMERIC\n)'
+    table2 = fresh_db.create_table("t2", {"id": int, "misc": "ANY"}, pk="id")
+    assert table2.schema == 'CREATE TABLE "t2" (\n   "id" INTEGER PRIMARY KEY,\n   "misc" ANY\n)'
+
+
 def test_create_table_with_bad_not_null(fresh_db):
     with pytest.raises(ValueError):
         fresh_db.create_table(
@@ -375,6 +382,18 @@ def test_create_error_if_invalid_self_referential_foreign_keys(fresh_db):
             'CREATE TABLE "dogs" (\n   "name" TEXT\n, "float" FLOAT)',
         ),
         ("blob", "blob", None, 'CREATE TABLE "dogs" (\n   "name" TEXT\n, "blob" BLOB)'),
+        (
+            "score",
+            "NUMERIC",
+            None,
+            'CREATE TABLE "dogs" (\n   "name" TEXT\n, "score" NUMERIC)',
+        ),
+        (
+            "misc",
+            "ANY",
+            None,
+            'CREATE TABLE "dogs" (\n   "name" TEXT\n, "misc" ANY)',
+        ),
         (
             "default_str",
             None,


### PR DESCRIPTION
Passing a valid SQLite type string not present in `COLUMN_TYPE_MAPPING` — such as `"NUMERIC"` or `"ANY"` — to `create_table` or `add_column` raises `KeyError` instead of using the string as-is. The documentation for both methods explicitly states that `col_type` accepts "a Python type such as `str` or a SQLite type string such as `BLOB`", so any string should be accepted and passed through to SQLite unchanged. The fix uses `.get()` on the mapping and falls back to the raw string when the type is an unrecognised string, leaving all existing behaviour unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D64sL9zHw5yben2ZRnuar6)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--818.org.readthedocs.build/en/818/

<!-- readthedocs-preview sqlite-utils end -->