### PR TITLE
fix: allow rows_where(offset=...) without limit

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2003,6 +2003,9 @@ class Queryable:
         if limit is not None:
             sql += f" limit {limit}"
         if offset is not None:
+            # SQLite requires LIMIT when OFFSET is used (issue #816).
+            if limit is None:
+                sql += " limit -1"
             sql += f" offset {offset}"
         cursor = self.db.execute(sql, where_args or [])
         columns = dedupe_keys(c[0] for c in cursor.description)
@@ -3594,6 +3597,9 @@ class Table(Queryable):
         if limit is not None:
             limit_offset += f" limit {limit}"
         if offset is not None:
+            # SQLite requires LIMIT when OFFSET is used (issue #816).
+            if limit is None and " limit " not in limit_offset:
+                limit_offset += " limit -1"
             limit_offset += f" offset {offset}"
         return sql.format(
             dbtable=quote_identifier(self.name),


### PR DESCRIPTION
## Summary
`rows_where(offset=N)` without `limit` produced invalid SQL because SQLite requires LIMIT with OFFSET.

## Change
When `offset` is set and `limit` is omitted, emit `LIMIT -1` before OFFSET.

Fixes #816


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--819.org.readthedocs.build/en/819/

<!-- readthedocs-preview sqlite-utils end -->