### PR TITLE
Fix transform() corrupting ANY columns on STRICT tables to REAL

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -343,6 +343,8 @@ COLUMN_TYPE_MAPPING: dict[Any, str] = {
     "real": "REAL",
     "blob": "BLOB",
     "bytes": "BLOB",
+    "ANY": "ANY",
+    "any": "ANY",
 }
 # If numpy is available, add more types
 if np:

--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -177,6 +177,8 @@ def column_affinity(column_type: str) -> type:
         return bytes
     if "REAL" in column_type or "FLOA" in column_type or "DOUB" in column_type:
         return float
+    if column_type == "ANY":
+        return "ANY"  # type: ignore[return-value]
     # Default is 'NUMERIC', which we currently also treat as float
     return float
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -785,6 +785,28 @@ def test_transform_to_strict_not_supported(fresh_db, method_name):
     assert table.strict is False
 
 
+def test_transform_preserves_any_column_in_strict_table(fresh_db):
+    if not fresh_db.supports_strict:
+        pytest.skip("SQLite version does not support strict tables")
+    fresh_db.conn.execute(
+        "create table things (id integer primary key, data any) strict"
+    )
+    fresh_db.conn.execute("insert into things values (1, 42)")
+    fresh_db.conn.execute("insert into things values (2, 'text')")
+    fresh_db.conn.execute("insert into things values (3, 3.14)")
+    table = fresh_db["things"]
+
+    # transform() must preserve ANY columns without crashing or changing the type
+    table.transform()
+    assert table.strict is True
+    assert table.columns_dict == {"id": int, "data": "ANY"}
+    assert list(table.rows) == [
+        {"id": 1, "data": 42},
+        {"id": 2, "data": "text"},
+        {"id": 3, "data": 3.14},
+    ]
+
+
 @pytest.mark.parametrize(
     "indexes, transform_params",
     [


### PR DESCRIPTION
SQLite's `ANY` column type (only valid in STRICT tables) was not handled by `column_affinity()`. The function fell through all its checks and returned `float`, which then mapped to `REAL` in `COLUMN_TYPE_MAPPING`. As a result, calling `transform()` on a STRICT table with `ANY` columns either crashed with `IntegrityError: cannot store TEXT value in REAL column` when rows held non-numeric data, or silently changed the column type from `ANY` to `REAL`.

The fix adds `ANY` as an explicit case in `column_affinity()` — it returns the string `"ANY"` rather than `float` — and registers `"ANY"` and `"any"` in `COLUMN_TYPE_MAPPING` so that `create_table_sql()` emits the correct column type. Both the strict-to-strict and strict-to-non-strict transform paths now preserve `ANY` columns unchanged.

A regression test is included that creates a STRICT table with an `ANY` column, inserts rows with integer, text, and float values, and verifies that `transform()` completes without error and preserves the column type and all row data.

Fixes #790

---
_Generated by [Claude Code](https://claude.ai/code/session_01P21wrXuJbMCwW8gNsYoWVM)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--820.org.readthedocs.build/en/820/

<!-- readthedocs-preview sqlite-utils end -->