### PR TITLE
Emit LIMIT -1 when offset is used without limit

### DIFF
--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -2478,8 +2478,6 @@ def rows(
     if limit:
         sql += f" limit {limit}"
     if offset:
-        # SQLite requires a limit clause before offset - a negative limit
-        # means "no upper bound", so offset works without an explicit limit
         if not limit:
             sql += " limit -1"
         sql += f" offset {offset}"

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -2478,6 +2478,10 @@ def rows(
     if limit:
         sql += f" limit {limit}"
     if offset:
+        # SQLite requires a limit clause before offset - a negative limit
+        # means "no upper bound", so offset works without an explicit limit
+        if not limit:
+            sql += " limit -1"
         sql += f" offset {offset}"
     ctx.invoke(
         query,

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -3598,8 +3598,6 @@ class Table(Queryable):
         if limit is not None:
             limit_offset += f" limit {limit}"
         if offset is not None:
-            # SQLite requires a limit clause before offset - a negative limit
-            # means "no upper bound", so offset works without an explicit limit
             if limit is None:
                 limit_offset += " limit -1"
             limit_offset += f" offset {offset}"

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2003,6 +2003,10 @@ class Queryable:
         if limit is not None:
             sql += f" limit {limit}"
         if offset is not None:
+            # SQLite requires a limit clause before offset - a negative limit
+            # means "no upper bound", so offset works without an explicit limit
+            if limit is None:
+                sql += " limit -1"
             sql += f" offset {offset}"
         cursor = self.db.execute(sql, where_args or [])
         columns = dedupe_keys(c[0] for c in cursor.description)
@@ -3594,6 +3598,10 @@ class Table(Queryable):
         if limit is not None:
             limit_offset += f" limit {limit}"
         if offset is not None:
+            # SQLite requires a limit clause before offset - a negative limit
+            # means "no upper bound", so offset works without an explicit limit
+            if limit is None:
+                limit_offset += " limit -1"
             limit_offset += f" offset {offset}"
         return sql.format(
             dbtable=quote_identifier(self.name),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1183,6 +1183,11 @@ def test_query_memory_does_not_create_file(tmpdir):
             ["-c", "name", "--limit", "1", "--offset", "1"],
             '[{"name": "Pancakes"}]',
         ),
+        # --offset without --limit
+        (
+            ["-c", "name", "--offset", "1"],
+            '[{"name": "Pancakes"}]',
+        ),
         # --where
         (
             ["-c", "name", "--where", "id = 1"],

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -112,6 +112,17 @@ def test_search_limit_offset(fresh_db):
     )
 
 
+def test_search_offset_without_limit(fresh_db):
+    table = fresh_db["t"]
+    table.insert_all(search_records)
+    table.enable_fts(["text", "country"], fts_version="FTS4")
+    assert [row["rowid"] for row in table.search("are", order_by="rowid")] == [1, 2]
+    assert [
+        row["rowid"] for row in table.search("are", offset=1, order_by="rowid")
+    ] == [2]
+    assert table.search_sql(offset=1).strip().endswith("limit -1 offset 1")
+
+
 @pytest.mark.parametrize("fts_version", ("FTS4", "FTS5"))
 def test_search_where(fresh_db, fts_version):
     table = fresh_db["t"]

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -59,6 +59,9 @@ def test_rows_where_order_by(where, order_by, expected_ids, fresh_db):
         (None, 3, [1, 2, 3]),
         (0, 3, [1, 2, 3]),
         (3, 3, [4, 5, 6]),
+        # offset without limit should return every remaining row
+        (97, None, [98, 99, 100]),
+        (0, None, list(range(1, 101))),
     ],
 )
 def test_rows_where_offset_limit(fresh_db, offset, limit, expected):
@@ -68,6 +71,12 @@ def test_rows_where_offset_limit(fresh_db, offset, limit, expected):
     assert expected == [
         r["id"] for r in table.rows_where(offset=offset, limit=limit, order_by="id")
     ]
+
+
+def test_pks_and_rows_where_offset_without_limit(fresh_db):
+    table = fresh_db["rows"]
+    table.insert_all([{"id": id} for id in range(1, 6)], pk="id")
+    assert [pk for pk, _ in table.pks_and_rows_where(offset=3, order_by="id")] == [4, 5]
 
 
 def test_pks_and_rows_where_rowid(fresh_db):


### PR DESCRIPTION
Fixes:
- #816.

SQLite requires a `LIMIT` clause to appear before `OFFSET`, so passing `offset` without `limit` generated invalid SQL:

```python
db["t"].rows_where(offset=2)
# select * from "t" offset 2
# OperationalError: near "2": syntax error
```

A negative limit means "no upper bound" in SQLite, so emitting `limit -1 offset N` returns all rows from position N onwards.

The issue mentions `rows_where()` and `search_sql()`. There is a third instance of the same pattern in the `sqlite-utils rows` CLI command, which fails the same way:

```
$ sqlite-utils rows data.db t --offset 1
Error: near "1": syntax error
```

So this fixes three sites:

- `Queryable.rows_where()` — also covers `pks_and_rows_where()`, which delegates to it
- `Table.search_sql()` — also covers `search()`
- the `sqlite-utils rows` CLI command

Tests added:

- two new cases in the existing `test_rows_where_offset_limit` parametrize (`offset` with `limit=None`, including `offset=0`)
- `test_pks_and_rows_where_offset_without_limit`
- `test_search_offset_without_limit`
- a new `--offset` without `--limit` case in the `sqlite-utils rows` CLI parametrize

Full suite passes (1379 passed, 16 skipped), plus `black --check`, `flake8` and `mypy` are clean.


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--821.org.readthedocs.build/en/821/

<!-- readthedocs-preview sqlite-utils end -->