### PR TITLE
Use quote_identifier() in indexes/xindexes PRAGMA statements

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2283,14 +2283,11 @@ class Table(Queryable):
     @property
     def indexes(self) -> list[Index]:
         "List of indexes defined on this table."
-        sql = f'PRAGMA index_list("{self.name}")'
+        sql = f"PRAGMA index_list({quote_identifier(self.name)})"
         indexes = []
         for row in self.db.execute_returning_dicts(sql):
             index_name = row["name"]
-            index_name_quoted = (
-                f'"{index_name}"' if not index_name.startswith('"') else index_name
-            )
-            column_sql = f"PRAGMA index_info({index_name_quoted})"
+            column_sql = f"PRAGMA index_info({quote_identifier(index_name)})"
             columns = []
             for seqno, cid, name in self.db.execute(column_sql).fetchall():
                 columns.append(name)
@@ -2305,14 +2302,11 @@ class Table(Queryable):
     @property
     def xindexes(self) -> list[XIndex]:
         "List of indexes defined on this table using the more detailed ``XIndex`` format."
-        sql = f'PRAGMA index_list("{self.name}")'
+        sql = f"PRAGMA index_list({quote_identifier(self.name)})"
         indexes = []
         for row in self.db.execute_returning_dicts(sql):
             index_name = row["name"]
-            index_name_quoted = (
-                f'"{index_name}"' if not index_name.startswith('"') else index_name
-            )
-            column_sql = f"PRAGMA index_xinfo({index_name_quoted})"
+            column_sql = f"PRAGMA index_xinfo({quote_identifier(index_name)})"
             index_columns = []
             for info in self.db.execute(column_sql).fetchall():
                 index_columns.append(XIndexColumn(*info))

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -153,6 +153,31 @@ def test_xindexes(fresh_db):
     ]
 
 
+def test_indexes_with_double_quotes_in_identifiers(fresh_db):
+    fresh_db['Go"sh'].insert({"id": 1, 'c"1': 2}, pk="id")
+    fresh_db['Go"sh'].create_index(['c"1'])
+    assert [(index.name, index.columns) for index in fresh_db['Go"sh'].indexes] == [
+        ('idx_Go"sh_c"1', ['c"1'])
+    ]
+    assert fresh_db['Go"sh'].xindexes == [
+        XIndex(
+            name='idx_Go"sh_c"1',
+            columns=[
+                XIndexColumn(seqno=0, cid=1, name='c"1', desc=0, coll="BINARY", key=1),
+                XIndexColumn(seqno=1, cid=-1, name=None, desc=0, coll="BINARY", key=0),
+            ],
+        )
+    ]
+
+
+def test_transform_table_with_double_quotes_in_identifiers(fresh_db):
+    fresh_db['Go"sh'].insert({"id": 1, 'c"1': 2, "c2": 3}, pk="id")
+    fresh_db['Go"sh'].create_index(['c"1'])
+    fresh_db['Go"sh'].transform(types={"c2": str})
+    assert fresh_db['Go"sh'].columns_dict["c2"] is str
+    assert [index.columns for index in fresh_db['Go"sh'].indexes] == [['c"1']]
+
+
 @pytest.mark.parametrize(
     "column,expected_table_guess",
     (


### PR DESCRIPTION
Refs:
- #824.

`Table.indexes` and `Table.xindexes` were the four remaining sites still using naive f-string quoting after the #678 migration (fb93452): `PRAGMA index_list("{self.name}")` never doubles an embedded `"`, and the index name was wrapped by a pre-2019 heuristic (`startswith('"')`) with the same flaw. Any identifier containing a double quote produced malformed SQL → `sqlite3.OperationalError`, and since `self.indexes` feeds `transform()`, `drop_index()` and `Database.create`, `transform()` failed outright for such tables — reachable from ordinary CSV/JSON imports whose headers contain quotes.

## Change

All four sites now use the project's own `quote_identifier()` (already used 103 times elsewhere in `db.py`, including the neighbouring `PRAGMA table_info` / `PRAGMA foreign_key_list`). Net −6 lines.

## Tests

Two regression tests in `tests/test_introspect.py`, placed after the existing `test_indexes`/`test_xindexes` and following their assertion style:

- `test_indexes_with_double_quotes_in_identifiers` — pins both properties on a table named `Go"sh` with an index on column `c"1`
- `test_transform_table_with_double_quotes_in_identifiers` — pins the `transform()` cascade so a regression in either property is caught

Red on main (both fail with `OperationalError: near "sh": syntax error`), green with the fix. Full suite: 1370 passed → 1372 passed, 20 skipped, nothing regressed. `black --check` clean.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--825.org.readthedocs.build/en/825/

<!-- readthedocs-preview sqlite-utils end -->