### PR TITLE
task/01KZ9VS57ETQG6JQ4Q6FAKXNQE

### DIFF
--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -317,6 +317,9 @@ See :ref:`cli_inserting_data`, :ref:`cli_insert_csv_tsv`, :ref:`cli_insert_unstr
       --alter                   Alter existing table to add any missing columns
       --not-null TEXT           Columns that should be created as NOT NULL
       --default <TEXT TEXT>...  Default value that should be set for a column
+      --extract TEXT            Extract this column into a separate lookup table,
+                                e.g. --extract species or --extract species:Species
+                                to use a custom table name
       --type <TEXT CHOICE>...   Column types to use when creating the table
       --no-detect-types         Treat all CSV/TSV columns as TEXT
       --analyze                 Run ANALYZE at the end of this operation
@@ -384,6 +387,9 @@ See :ref:`cli_upsert`.
       --alter                   Alter existing table to add any missing columns
       --not-null TEXT           Columns that should be created as NOT NULL
       --default <TEXT TEXT>...  Default value that should be set for a column
+      --extract TEXT            Extract this column into a separate lookup table,
+                                e.g. --extract species or --extract species:Species
+                                to use a custom table name
       --type <TEXT CHOICE>...   Column types to use when creating the table
       --no-detect-types         Treat all CSV/TSV columns as TEXT
       --analyze                 Run ANALYZE at the end of this operation
@@ -602,6 +608,12 @@ See :ref:`cli_insert_files`.
               -c size:size \
               --pk name
 
+      Use --convert to transform each row before it is inserted, the same way as
+      sqlite-utils convert:
+
+          sqlite-utils insert-files archive.db sqlar *.gif --sqlar \
+              --convert 'row["data"] = zlib.compress(row["data"])' --import zlib
+
     Options:
       -c, --column TEXT      Column definitions for the table
       --pk TEXT              Column to use as primary key
@@ -610,7 +622,11 @@ See :ref:`cli_insert_files`.
       --upsert               Upsert files with matching primary key
       --name TEXT            File name to use
       --text                 Store file content as TEXT, not BLOB
+      --sqlar                Store file content zlib-compressed, compatible with
+                             SQLite's sqlar format
       --encoding TEXT        Character encoding for input, defaults to utf-8
+      --convert TEXT         Python code to convert each row before insertion
+      --import TEXT          Python modules to import
       -s, --silent           Don't show a progress bar
       --load-extension TEXT  Path to SQLite extension, with optional :entrypoint
       -h, --help             Show this message and exit.

--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -136,6 +136,8 @@ See :ref:`cli_query`.
                                   escaped strings
       --ascii                     Escape non-ASCII characters in JSON output as
                                   \uXXXX
+      -x, --transpose             Transpose wide rows, one key/value pair per line
+                                  (like psql's \x)
       -r, --raw                   Raw output, first column of first row
       --raw-lines                 Raw output, first column of each row
       -p, --param <TEXT TEXT>...  Named :parameters for SQL query
@@ -207,6 +209,8 @@ See :ref:`cli_memory`.
                                   escaped strings
       --ascii                     Escape non-ASCII characters in JSON output as
                                   \uXXXX
+      -x, --transpose             Transpose wide rows, one key/value pair per line
+                                  (like psql's \x)
       -r, --raw                   Raw output, first column of first row
       --raw-lines                 Raw output, first column of each row
       -p, --param <TEXT TEXT>...  Named :parameters for SQL query
@@ -478,6 +482,8 @@ See :ref:`cli_search`.
       --json-cols            Detect JSON cols and output them as JSON, not escaped
                              strings
       --ascii                Escape non-ASCII characters in JSON output as \uXXXX
+      -x, --transpose        Transpose wide rows, one key/value pair per line (like
+                             psql's \x)
       --load-extension TEXT  Path to SQLite extension, with optional :entrypoint
       -h, --help             Show this message and exit.
 
@@ -842,6 +848,8 @@ See :ref:`cli_rows`.
                                   escaped strings
       --ascii                     Escape non-ASCII characters in JSON output as
                                   \uXXXX
+      -x, --transpose             Transpose wide rows, one key/value pair per line
+                                  (like psql's \x)
       --load-extension TEXT       Path to SQLite extension, with optional
                                   :entrypoint
       -h, --help                  Show this message and exit.

--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -293,6 +293,9 @@ See :ref:`cli_inserting_data`, :ref:`cli_insert_csv_tsv`, :ref:`cli_insert_unstr
       --flatten                 Flatten nested JSON objects, so {"a": {"b": 1}}
                                 becomes {"a_b": 1}
       --nl                      Expect newline-delimited JSON
+      --key TEXT                If input is a JSON object, import the array of
+                                records under this key, e.g. --key results for
+                                {"results": [...]}
       -c, --csv                 Expect CSV input
       --tsv                     Expect TSV input
       --empty-null              Treat empty strings as NULL
@@ -357,6 +360,9 @@ See :ref:`cli_upsert`.
       --flatten                 Flatten nested JSON objects, so {"a": {"b": 1}}
                                 becomes {"a_b": 1}
       --nl                      Expect newline-delimited JSON
+      --key TEXT                If input is a JSON object, import the array of
+                                records under this key, e.g. --key results for
+                                {"results": [...]}
       -c, --csv                 Expect CSV input
       --tsv                     Expect TSV input
       --empty-null              Treat empty strings as NULL
@@ -412,6 +418,9 @@ See :ref:`cli_bulk`.
       --flatten              Flatten nested JSON objects, so {"a": {"b": 1}} becomes
                              {"a_b": 1}
       --nl                   Expect newline-delimited JSON
+      --key TEXT             If input is a JSON object, import the array of records
+                             under this key, e.g. --key results for {"results":
+                             [...]}
       -c, --csv              Expect CSV input
       --tsv                  Expect TSV input
       --empty-null           Treat empty strings as NULL

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1200,6 +1200,24 @@ You can add the ``--analyze`` option to run ``ANALYZE`` against the table after 
 .. note::
     In Python: :ref:`table.insert_all() <python_api_bulk_inserts>`  CLI reference: :ref:`sqlite-utils insert <cli_ref_insert>`
 
+If your JSON is a single object with the list of records nested under a key, use ``--key`` to select it.
+For example, if ``dogs.json`` looks like this:
+
+.. code-block:: json
+
+    {
+        "List": [
+            {"id": 1, "name": "Cleo"},
+            {"id": 2, "name": "Pancakes"}
+        ]
+    }
+
+You can import the records under the ``List`` key like so:
+
+.. code-block:: bash
+
+    sqlite-utils insert dogs.db dogs dogs.json --key List
+
 .. _cli_inserting_data_binary:
 
 Inserting binary data

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1748,6 +1748,16 @@ Pass ``--sqlar`` to store the content zlib-compressed instead, using the same ``
 
 Content is only stored compressed if doing so makes it smaller - otherwise the original bytes are stored as-is, matching the behaviour of SQLite's ``sqlar_compress()`` function.
 
+You can use ``--convert`` to transform each row before it is inserted, so imports that need custom logic - like compressing content into an archive format - don't need a separate :ref:`sqlite-utils convert <cli_convert>` command run against the table afterwards. It works the same way as the ``--convert`` option on :ref:`insert and upsert <cli_insert_convert>`, with a ``row`` variable available to modify in place:
+
+.. code-block:: bash
+
+    sqlite-utils insert-files archive.db sqlar *.gif \
+        -c name:name -c mode:mode -c mtime:mtime_int -c sz:size -c data:content \
+        --convert 'row["data"] = zlib.compress(row["data"])' --import zlib
+
+As with ``sqlite-utils convert`` you can use ``--import`` to import additional Python modules, and the same :ref:`recipe functions <cli_convert_recipes>` are available via ``r.``.
+
 You can customize the schema using one or more ``-c`` options. For a table schema that includes just the path, MD5 hash and last modification time of the file, you would use this:
 
 .. code-block:: bash

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1747,6 +1747,13 @@ You can change the name of one of these columns using a ``-c colname:coldef`` pa
     sqlite-utils insert-files gifs.db images *.gif \
         -c path -c md5 -c last_modified:mtime --pk=path
 
+You can also populate a column with a fixed value for every file using a ``-c colname:text:value`` parameter. This is useful for tagging every row from a given import with the same value, without a separate update pass:
+
+.. code-block:: bash
+
+    sqlite-utils insert-files gifs.db images *.gif \
+        -c path -c content -c file_type:text:gif --pk=path
+
 You can pass ``--replace`` or ``--upsert`` to indicate what should happen if you try to insert a file with an existing primary key. Pass ``--alter`` to cause any missing columns to be added to the table.
 
 The full list of column definitions you can use is as follows:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1740,6 +1740,14 @@ By default this command will create a table with the following schema:
 
 Content will be treated as binary by default and stored in a ``BLOB`` column. You can use the ``--text`` option to store that content in a ``TEXT`` column instead.
 
+Pass ``--sqlar`` to store the content zlib-compressed instead, using the same ``name``, ``mode``, ``mtime``, ``sz`` and ``data`` columns as `SQLite's own sqlar archive format <https://sqlite.org/sqlar.html>`__:
+
+.. code-block:: bash
+
+    sqlite-utils insert-files archive.db sqlar *.gif --sqlar
+
+Content is only stored compressed if doing so makes it smaller - otherwise the original bytes are stored as-is, matching the behaviour of SQLite's ``sqlar_compress()`` function.
+
 You can customize the schema using one or more ``-c`` options. For a table schema that includes just the path, MD5 hash and last modification time of the file, you would use this:
 
 .. code-block:: bash
@@ -1792,6 +1800,8 @@ The full list of column definitions you can use is as follows:
     The binary file contents, which will be stored as a BLOB
 ``content_text``
     The text file contents, which will be stored as TEXT
+``content_sqlar``
+    The file contents zlib-compressed for storage in a ``sqlar``-compatible BLOB column, matching the behaviour of ``--sqlar`` - the content is left uncompressed if compression would not make it smaller
 ``mtime``
     The modification time of the file, as floating point seconds since the Unix epoch
 ``ctime``
@@ -1819,7 +1829,7 @@ You can insert data piped from standard input like this:
 
 The ``-`` argument indicates data should be read from standard input. The string passed using the ``--name`` option will be used for the file name and path values.
 
-When inserting data from standard input only the following column definitions are supported: ``name``, ``path``, ``content``, ``content_text``, ``sha256``, ``md5`` and ``size``.
+When inserting data from standard input only the following column definitions are supported: ``name``, ``path``, ``content``, ``content_text``, ``content_sqlar``, ``sha256``, ``md5`` and ``size``.
 
 .. _cli_convert:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1445,6 +1445,31 @@ The column type should be one of ``TEXT``, ``INTEGER``, ``FLOAT``, ``REAL`` or `
 
 As with detected column types, ``--type`` only affects tables created by the command. If the table already exists, its existing column types are left unchanged.
 
+.. _cli_insert_extract:
+
+Extracting columns into a separate table
+-----------------------------------------
+
+Use ``--extract column-name`` to extract a column out into a separate lookup table during the insert, instead of running a separate :ref:`extract <cli_extract>` command afterwards.
+
+This can be used more than once, and works with both ``insert`` and ``upsert``:
+
+.. code-block:: bash
+
+    sqlite-utils insert trees.db trees trees.csv --csv \
+        --extract species
+
+This creates a ``species`` lookup table containing one row per distinct value, and replaces the ``species`` column on ``trees`` with a foreign key reference to it.
+
+To use a different name for the lookup table, add it after a colon:
+
+.. code-block:: bash
+
+    sqlite-utils insert trees.db trees trees.csv --csv \
+        --extract species:Species
+
+See :ref:`python_api_extracts` for more details on how this works, including how ``null`` values are handled.
+
 To disable type detection and treat all columns as TEXT, use ``--no-detect-types``:
 
 .. code-block:: bash

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -337,6 +337,31 @@ Available ``--fmt`` options are:
 
 This list can also be found by running ``sqlite-utils query --help``.
 
+.. _cli_query_transpose:
+
+Transposed output for wide rows
+--------------------------------
+
+If your rows have a lot of columns they can be hard to read as a table.
+Use the ``--transpose`` option (or the ``-x`` shortcut, matching ``psql``'s ``\x``) to display each row as a block of key/value pairs instead:
+
+.. code-block:: bash
+
+    sqlite-utils dogs.db "select * from dogs" --transpose
+
+.. code-block:: output
+
+    -[ RECORD 1 ]--
+    id   | 1
+    age  | 4
+    name | Cleo
+    -[ RECORD 2 ]--
+    id   | 2
+    age  | 2
+    name | Pancakes
+
+Combine this with ``--no-headers`` to omit the ``-[ RECORD n ]-`` separator lines.
+
 .. _cli_query_raw:
 
 Returning raw data, such as binary content
@@ -480,7 +505,7 @@ Without any extra arguments, this command executes SQL against the in-memory dat
 
     [{"sqlite_version()": "3.35.5"}]
 
-It takes all of the same output formatting options as :ref:`sqlite-utils query <cli_query>`: ``--csv`` and ``--csv`` and ``--table`` and ``--nl``:
+It takes all of the same output formatting options as :ref:`sqlite-utils query <cli_query>`: ``--csv`` and ``--table`` and ``--nl`` and ``--transpose``:
 
 .. code-block:: bash
 
@@ -690,7 +715,7 @@ You can return every row in a specified table using the ``rows`` command:
     [{"id": 1, "age": 4, "name": "Cleo"},
      {"id": 2, "age": 2, "name": "Pancakes"}]
 
-This command accepts the same output options as ``query`` - so you can pass ``--nl``, ``--csv``, ``--tsv``, ``--no-headers``, ``--table`` and ``--fmt``.
+This command accepts the same output options as ``query`` - so you can pass ``--nl``, ``--csv``, ``--tsv``, ``--no-headers``, ``--table``, ``--fmt`` and ``--transpose`` (see :ref:`cli_query_transpose`).
 
 You can use the ``-c`` option to specify a subset of columns to return:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -192,7 +192,15 @@ If one of your columns contains JSON, by default it will be returned as an escap
         }
     ]
 
-You can use the ``--json-cols`` option to automatically detect these JSON columns and output them as nested JSON data:
+If the column is declared as type ``JSON`` in the table's schema, this happens automatically without needing ``--json-cols``:
+
+.. code-block:: bash
+
+    sqlite-utils dogs.db "CREATE TABLE dogs2 (id integer primary key, name text, friends JSON)"
+
+Columns declared this way are decoded as nested JSON by every command that returns JSON (``rows``, ``query``, ``search``, ``memory``), and by the Python library too. CSV, TSV and table output always show the underlying text, since flat formats cannot represent nested structures.
+
+For other TEXT columns that merely happen to contain a JSON string, you can use the ``--json-cols`` option to automatically detect these JSON columns and output them as nested JSON data:
 
 .. code-block:: bash
 

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -2287,6 +2287,21 @@ For example:
     """).fetchall()
     # Returns [('Felton, CA',)]
 
+Values read back out through the Python API - via ``.rows``, ``.rows_where()``, ``.get()``,
+``.search()`` or ``.query()`` - come back as the raw JSON string that was stored, not as a
+``dict`` or ``list``, since that is the value SQLite actually returned. Pass
+``deserialize_json=True`` to the ``Database()`` constructor to opt in to automatically parsing
+any string value that looks like a JSON object or array back into a ``dict`` or ``list``:
+
+.. code-block:: python
+
+    db = sqlite_utils.Database("museums.db", deserialize_json=True)
+    print(db["niche_museums"].get(1))
+    # {'id': 1, 'name': 'The Bigfoot Discovery Museum', ..., 'hours': {'Monday': [11, 18], ...}}
+
+This defaults to ``False``, so existing code that expects raw strings continues to work
+unchanged.
+
 .. _python_api_conversions:
 
 Converting column values using SQL functions

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -3307,6 +3307,29 @@ The ``sqlite_utils.utils.rows_from_file()`` helper function can read rows (a seq
 .. autofunction:: sqlite_utils.utils.rows_from_file
    :noindex:
 
+.. _python_api_rows_to_csv:
+
+Writing rows to CSV
+===================
+
+The CLI can render query and table output as CSV using ``--csv``, see :ref:`cli_query_csv`. The ``sqlite_utils.utils.rows_to_csv()`` helper provides the same behavior from the Python API - pass it rows from :meth:`db.query() <python_api_query>` or ``table.rows`` / ``table.rows_where()`` and it writes CSV to a file-like object, or returns the CSV as a string if you don't pass one:
+
+.. code-block:: python
+
+    from sqlite_utils.utils import rows_to_csv
+
+    db = Database("dogs.db")
+    csv_string = rows_to_csv(db["dogs"].rows)
+
+    # Or write directly to a file:
+    with open("dogs.csv", "w", newline="") as fp:
+        rows_to_csv(db["dogs"].rows, fp=fp)
+
+Like the CLI, a header row is included by default - taken from the keys of the first row - and can be skipped with ``no_headers=True``.
+
+.. autofunction:: sqlite_utils.utils.rows_to_csv
+   :noindex:
+
 .. _python_api_maximize_csv_field_size_limit:
 
 Setting the maximum CSV field size limit

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -1564,12 +1564,13 @@ You can add a new column to a table using the ``.add_column(col_name, col_type)`
     db.table("dogs").add_column("dob", datetime.date)
     db.table("dogs").add_column("image", "BLOB")
     db.table("dogs").add_column("website") # str by default
+    db.table("dogs").add_column("friends", "JSON")
 
 You can specify the ``col_type`` argument either using a SQLite type as a string, or by directly passing a Python type e.g. ``str`` or ``float``.
 
 The ``col_type`` is optional - if you omit it the type of ``TEXT`` will be used.
 
-SQLite types you can specify are ``"TEXT"``, ``"INTEGER"``, ``"FLOAT"``, ``"REAL"`` or ``"BLOB"``.
+SQLite types you can specify are ``"TEXT"``, ``"INTEGER"``, ``"FLOAT"``, ``"REAL"``, ``"BLOB"`` or ``"JSON"``. A column declared as ``"JSON"`` will be automatically decoded back into a Python object (rather than a JSON string) whenever it is read, both by the Python library and by the :ref:`CLI <cli_json_values>`.
 
 If you pass a Python type, it will be mapped to SQLite types as shown here::
 

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -2302,6 +2302,56 @@ any string value that looks like a JSON object or array back into a ``dict`` or 
 This defaults to ``False``, so existing code that expects raw strings continues to work
 unchanged.
 
+.. _python_api_custom_json:
+
+Custom JSON encoding and decoding
+----------------------------------
+
+By default, values that are not natively JSON-serializable - such as
+``set``, ``enum.Enum`` members or custom classes - are converted using
+``repr()`` when they are written to a JSON column, since ``dict``, ``list``
+and ``tuple`` values are always serialized with ``json.dumps()``. To take
+full control of that conversion, pass a ``json_default`` function to the
+``Database()`` constructor - it is used as the ``default=`` callback to
+``json.dumps()``:
+
+.. code-block:: python
+
+    import enum
+
+    class Color(enum.Enum):
+        RED = "red"
+        BLUE = "blue"
+
+    def encode(value):
+        if isinstance(value, set):
+            return list(value)
+        if isinstance(value, enum.Enum):
+            return value.value
+        raise TypeError(f"Cannot serialize {value!r}")
+
+    db = sqlite_utils.Database("data.db", json_default=encode)
+    db["examples"].insert({"id": 1, "tags": {"a", "b"}, "color": Color.RED})
+
+To reconstruct custom types when reading rows back with
+``deserialize_json=True``, pass a ``json_object_hook`` function - it is
+used as the ``object_hook=`` callback to ``json.loads()`` and is called
+with every JSON object (``dict``) encountered while parsing:
+
+.. code-block:: python
+
+    def decode(obj):
+        if "__color__" in obj:
+            return Color(obj["__color__"])
+        return obj
+
+    db = sqlite_utils.Database(
+        "data.db", deserialize_json=True, json_object_hook=decode
+    )
+
+Both options apply to every table on that ``Database`` connection - there is
+no per-table equivalent, matching how ``deserialize_json`` works.
+
 .. _python_api_conversions:
 
 Converting column values using SQL functions

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -1409,6 +1409,8 @@ To extract the ``species`` column out to a separate ``Species`` table, you can d
 
 ``None`` values are not extracted: no record is created for them in the lookup table and the column value stays ``null``.
 
+The ``sqlite-utils insert`` and ``sqlite-utils upsert`` commands expose this as the ``--extract`` option, see :ref:`cli_insert_extract`.
+
 .. _python_api_m2m:
 
 Working with many-to-many relationships

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -94,6 +94,13 @@ sqlite_utils.utils.rows_from_file
 
 .. autofunction:: sqlite_utils.utils.rows_from_file
 
+.. _reference_utils_rows_to_csv:
+
+sqlite_utils.utils.rows_to_csv
+------------------------------
+
+.. autofunction:: sqlite_utils.utils.rows_to_csv
+
 .. _reference_utils_typetracker:
 
 sqlite_utils.utils.TypeTracker

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -928,6 +928,10 @@ _import_options = (
         help='Flatten nested JSON objects, so {"a": {"b": 1}} becomes {"a_b": 1}',
     ),
     click.option("--nl", is_flag=True, help="Expect newline-delimited JSON"),
+    click.option(
+        "--key",
+        help='If input is a JSON object, import the array of records under this key, e.g. --key results for {"results": [...]}',
+    ),
     click.option("-c", "--csv", is_flag=True, help="Expect CSV input"),
     click.option("--tsv", is_flag=True, help="Expect TSV input"),
     click.option("--empty-null", is_flag=True, help="Treat empty strings as NULL"),
@@ -1071,6 +1075,7 @@ def insert_upsert_implementation(
     stop_after,
     alter,
     upsert,
+    key=None,
     ignore=False,
     replace=False,
     truncate=False,
@@ -1186,6 +1191,7 @@ def insert_upsert_implementation(
                 delimiter,
                 quotechar,
                 encoding,
+                key,
             ]
         ):
             raise click.ClickException(
@@ -1203,6 +1209,10 @@ def insert_upsert_implementation(
         csv = True
     if (nl + csv + tsv) >= 2:
         raise click.ClickException("Use just one of --nl, --csv or --tsv")
+    if key and (nl or csv or tsv or lines or text):
+        raise click.ClickException(
+            "--key cannot be used with --nl, --csv, --tsv, --lines or --text"
+        )
     if (csv or tsv) and flatten:
         raise click.ClickException("--flatten cannot be used with --csv or --tsv")
     if empty_null and not (csv or tsv):
@@ -1267,7 +1277,17 @@ def insert_upsert_implementation(
                     docs = (json.loads(line) for line in decoded if line.strip())
                 else:
                     docs = json.load(decoded)
-                    if isinstance(docs, dict):
+                    if key:
+                        if not isinstance(docs, dict) or key not in docs:
+                            raise click.ClickException(
+                                f"JSON key '{key}' not found in input"
+                            )
+                        docs = docs[key]
+                        if not isinstance(docs, list):
+                            raise click.ClickException(
+                                f"JSON key '{key}' is not a list"
+                            )
+                    elif isinstance(docs, dict):
                         docs = [docs]
             except json.decoder.JSONDecodeError as ex:
                 raise click.ClickException(
@@ -1350,6 +1370,7 @@ def insert(
     code,
     flatten,
     nl,
+    key,
     csv,
     tsv,
     empty_null,
@@ -1459,6 +1480,7 @@ def insert(
             stop_after,
             alter=alter,
             upsert=False,
+            key=key,
             ignore=ignore,
             replace=replace,
             truncate=truncate,
@@ -1486,6 +1508,7 @@ def upsert(
     code,
     flatten,
     nl,
+    key,
     csv,
     tsv,
     empty_null,
@@ -1552,6 +1575,7 @@ def upsert(
             stop_after,
             alter=alter,
             upsert=True,
+            key=key,
             not_null=not_null,
             default=default,
             types=types,
@@ -1586,6 +1610,7 @@ def bulk(
     functions,
     flatten,
     nl,
+    key,
     csv,
     tsv,
     empty_null,
@@ -1621,6 +1646,7 @@ def bulk(
             pk=None,
             flatten=flatten,
             nl=nl,
+            key=key,
             csv=csv,
             tsv=tsv,
             empty_null=empty_null,

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -2923,6 +2923,14 @@ def extract(
     "--encoding",
     help="Character encoding for input, defaults to utf-8",
 )
+@click.option("--convert", help="Python code to convert each row before insertion")
+@click.option(
+    "--import",
+    "imports",
+    type=str,
+    multiple=True,
+    help="Python modules to import",
+)
 @click.option("-s", "--silent", is_flag=True, help="Don't show a progress bar")
 @load_extension_option
 def insert_files(
@@ -2938,6 +2946,8 @@ def insert_files(
     text,
     sqlar,
     encoding,
+    convert,
+    imports,
     silent,
     load_extension,
 ):
@@ -2955,9 +2965,22 @@ def insert_files(
             -c modified:mtime_iso \\
             -c size:size \\
             --pk name
+
+    Use --convert to transform each row before it is inserted, the same way
+    as sqlite-utils convert:
+
+    \b
+        sqlite-utils insert-files archive.db sqlar *.gif --sqlar \\
+            --convert 'row["data"] = zlib.compress(row["data"])' --import zlib
     """
     if text and sqlar:
         raise click.ClickException("Cannot use --text and --sqlar together")
+    convert_fn = None
+    if convert:
+        try:
+            convert_fn = _compile_code(convert, imports, variable="row")
+        except SyntaxError as e:
+            raise click.ClickException(str(e))
     if not column:
         if text:
             column = ["path:path", "content_text:content_text", "size:size"]
@@ -3051,6 +3074,8 @@ def insert_files(
                     # Special case for --name
                     if coltype == "name" and name:
                         row[colname] = name
+                if convert_fn is not None:
+                    row = convert_fn(row) or row
                 yield row
 
         db = sqlite_utils.Database(path)

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -11,6 +11,7 @@ import pathlib
 import pdb  # noqa: T100
 import sys
 import textwrap
+import zlib
 from datetime import datetime, timezone
 from runpy import run_module
 from typing import Any
@@ -2914,6 +2915,11 @@ def extract(
 @click.option("--name", type=str, help="File name to use")
 @click.option("--text", is_flag=True, help="Store file content as TEXT, not BLOB")
 @click.option(
+    "--sqlar",
+    is_flag=True,
+    help="Store file content zlib-compressed, compatible with SQLite's sqlar format",
+)
+@click.option(
     "--encoding",
     help="Character encoding for input, defaults to utf-8",
 )
@@ -2930,6 +2936,7 @@ def insert_files(
     upsert,
     name,
     text,
+    sqlar,
     encoding,
     silent,
     load_extension,
@@ -2949,13 +2956,23 @@ def insert_files(
             -c size:size \\
             --pk name
     """
+    if text and sqlar:
+        raise click.ClickException("Cannot use --text and --sqlar together")
     if not column:
         if text:
             column = ["path:path", "content_text:content_text", "size:size"]
+        elif sqlar:
+            column = [
+                "name:name",
+                "mode:mode",
+                "mtime:mtime_int",
+                "sz:size",
+                "data:content_sqlar",
+            ]
         else:
             column = ["path:path", "content:content", "size:size"]
         if not pks:
-            pks = ["path"]
+            pks = ["name"] if sqlar else ["path"]
 
     def yield_paths_and_relative_paths():
         for f_or_d in file_or_dir:
@@ -2996,6 +3013,9 @@ def insert_files(
                         "content": lambda p, data=stdin_data: data,
                         "content_text": lambda p, data=stdin_data: data.decode(
                             encoding or "utf-8"
+                        ),
+                        "content_sqlar": lambda p, data=stdin_data: sqlar_compress(
+                            data
                         ),
                         "sha256": lambda p, data=stdin_data: hashlib.sha256(
                             data
@@ -3688,6 +3708,14 @@ class UnicodeDecodeErrorForPath(Exception):
         self.path = path
 
 
+def sqlar_compress(data):
+    # Matches SQLite's sqlar_compress(): use the zlib-compressed blob only
+    # if it is actually smaller than the original, otherwise store as-is.
+    # https://sqlite.org/sqlar.html
+    compressed = zlib.compress(data)
+    return compressed if len(compressed) < len(data) else data
+
+
 FILE_COLUMNS = {
     "name": lambda p: p.name,
     "path": lambda p: str(p),
@@ -3696,6 +3724,7 @@ FILE_COLUMNS = {
     "md5": lambda p: hashlib.md5(p.resolve().read_bytes()).hexdigest(),
     "mode": lambda p: p.stat().st_mode,
     "content": lambda p: p.resolve().read_bytes(),
+    "content_sqlar": lambda p: sqlar_compress(p.resolve().read_bytes()),
     "mtime": lambda p: p.stat().st_mtime,
     "ctime": lambda p: p.stat().st_ctime,
     "mtime_int": lambda p: int(p.stat().st_mtime),

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -2323,14 +2323,14 @@ def _execute_query(
         cursor_or_rows: Any = cursor
         if raw:
             row = cursor_or_rows.fetchone()
-            data = row[0] if row else None
+            data = _flatten_json(row[0]) if row else None
             if isinstance(data, bytes):
                 sys.stdout.buffer.write(data)
             else:
                 sys.stdout.write(str(data))
         elif raw_lines:
             for row in cursor:
-                data = row[0]
+                data = _flatten_json(row[0])
                 if isinstance(data, bytes):
                     sys.stdout.buffer.write(data + b"\n")
                 else:
@@ -2341,7 +2341,7 @@ def _execute_query(
         elif fmt or table:
             print(
                 tabulate.tabulate(
-                    list(cursor),
+                    [[_flatten_json(value) for value in row] for row in cursor],
                     headers=() if no_headers else headers,
                     tablefmt=fmt or "simple",
                 )
@@ -2351,7 +2351,7 @@ def _execute_query(
             if not no_headers:
                 writer.writerow(headers)
             for row in cursor:
-                writer.writerow(row)
+                writer.writerow([_flatten_json(value) for value in row])
         else:
             for line in output_rows(cursor, headers, nl, arrays, json_cols, ascii_):
                 click.echo(line)
@@ -3826,7 +3826,9 @@ def output_rows(iterator, headers, nl, arrays, json_cols, ascii_=False):
 def output_transpose(rows, headers, no_headers):
     # psql-style extended display: one "key = value" block per row
     headers = [str(h) for h in headers]
-    str_rows = [["" if v is None else str(v) for v in row] for row in rows]
+    str_rows = [
+        ["" if v is None else str(_flatten_json(v)) for v in row] for row in rows
+    ]
     key_width = max([len(h) for h in headers], default=0)
     val_width = max([len(v) for row in str_rows for v in row], default=0)
     total_width = key_width + 3 + val_width
@@ -3835,6 +3837,15 @@ def output_transpose(rows, headers, no_headers):
             yield "-[ RECORD {} ]-".format(i).ljust(total_width, "-")
         for header, value in zip(headers, row):
             yield "{} | {}".format(header.ljust(key_width), value)
+
+
+def _flatten_json(value):
+    # Columns declared as JSON are auto-decoded to dict/list by the sqlite3
+    # driver (see issue 579) - flat output formats (CSV/TSV/table/raw) need
+    # that turned back into a JSON string rather than a Python repr
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return value
 
 
 def maybe_json(value):

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -2978,8 +2978,19 @@ def insert_files(
                         "size": lambda p, data=stdin_data: len(data),
                     }
                 for coldef in column:
-                    if ":" in coldef:
-                        colname, coltype = coldef.rsplit(":", 1)
+                    parts = coldef.split(":", 2)
+                    if len(parts) == 3:
+                        # Fixed value, e.g. -c file_type:text:gif
+                        colname, coltype, fixed_value = parts
+                        if coltype != "text":
+                            raise click.ClickException(
+                                "Fixed value column definitions must use "
+                                "'colname:text:value', not '{}'".format(coldef)
+                            )
+                        row[colname] = fixed_value
+                        continue
+                    elif len(parts) == 2:
+                        colname, coltype = parts
                     else:
                         colname, coltype = coldef, coldef
                     try:

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -1027,6 +1027,14 @@ def insert_upsert_options(*, require_pk=False):
                     help="Default value that should be set for a column",
                 ),
                 click.option(
+                    "--extract",
+                    "extract",
+                    multiple=True,
+                    help="Extract this column into a separate lookup table, e.g. "
+                    "--extract species or --extract species:Species to use a "
+                    "custom table name",
+                ),
+                click.option(
                     "--type",
                     "types",
                     type=(
@@ -1091,6 +1099,7 @@ def insert_upsert_implementation(
     truncate=False,
     not_null=None,
     default=None,
+    extract=None,
     types=None,
     no_detect_types=False,
     analyze=False,
@@ -1119,6 +1128,10 @@ def insert_upsert_implementation(
             extra_kwargs["not_null"] = set(not_null)
         if default:
             extra_kwargs["defaults"] = dict(default)
+        if extract:
+            extra_kwargs["extracts"] = {
+                item.split(":", 1)[0]: item.split(":", 1)[-1] for item in extract
+            }
         if column_type_overrides:
             extra_kwargs["columns"] = column_type_overrides
         if upsert:
@@ -1405,6 +1418,7 @@ def insert(
     truncate,
     not_null,
     default,
+    extract,
     types,
     strict,
 ):
@@ -1500,6 +1514,7 @@ def insert(
             silent=silent,
             not_null=not_null,
             default=default,
+            extract=extract,
             types=types,
             strict=strict,
             code=code,
@@ -1536,6 +1551,7 @@ def upsert(
     alter,
     not_null,
     default,
+    extract,
     types,
     no_detect_types,
     analyze,
@@ -1588,6 +1604,7 @@ def upsert(
             key=key,
             not_null=not_null,
             default=default,
+            extract=extract,
             types=types,
             no_detect_types=no_detect_types,
             analyze=analyze,

--- a/sqlite_utils/cli.py
+++ b/sqlite_utils/cli.py
@@ -160,6 +160,15 @@ def load_extension_option(fn):
     )(fn)
 
 
+def transpose_option(fn):
+    return click.option(
+        "-x",
+        "--transpose",
+        is_flag=True,
+        help="Transpose wide rows, one key/value pair per line (like psql's \\x)",
+    )(fn)
+
+
 def functions_option(fn):
     return click.option(
         "--functions",
@@ -1992,6 +2001,7 @@ def drop_view(path, view, ignore, load_extension):
     help="Additional databases to attach - specify alias and filepath",
 )
 @output_options
+@transpose_option
 @click.option("-r", "--raw", is_flag=True, help="Raw output, first column of first row")
 @click.option("--raw-lines", is_flag=True, help="Raw output, first column of each row")
 @click.option(
@@ -2016,6 +2026,7 @@ def query(
     fmt,
     json_cols,
     ascii_,
+    transpose,
     raw,
     raw_lines,
     param,
@@ -2063,6 +2074,7 @@ def query(
         arrays,
         json_cols,
         ascii_,
+        transpose,
     )
 
 
@@ -2087,6 +2099,7 @@ def query(
     help='Flatten nested JSON objects, so {"foo": {"bar": 1}} becomes {"foo_bar": 1}',
 )
 @output_options
+@transpose_option
 @click.option("-r", "--raw", is_flag=True, help="Raw output, first column of first row")
 @click.option("--raw-lines", is_flag=True, help="Raw output, first column of each row")
 @click.option(
@@ -2134,6 +2147,7 @@ def memory(
     fmt,
     json_cols,
     ascii_,
+    transpose,
     raw,
     raw_lines,
     param,
@@ -2274,6 +2288,7 @@ def memory(
         arrays,
         json_cols,
         ascii_,
+        transpose,
     )
 
 
@@ -2292,6 +2307,7 @@ def _execute_query(
     arrays,
     json_cols,
     ascii_,
+    transpose=False,
 ):
     with db.conn:
         try:
@@ -2319,6 +2335,9 @@ def _execute_query(
                     sys.stdout.buffer.write(data + b"\n")
                 else:
                     sys.stdout.write(str(data) + "\n")
+        elif transpose:
+            for line in output_transpose(cursor, headers, no_headers):
+                click.echo(line)
         elif fmt or table:
             print(
                 tabulate.tabulate(
@@ -2358,6 +2377,7 @@ def _execute_query(
 )
 @click.option("--quote", is_flag=True, help="Apply FTS quoting rules to search term")
 @output_options
+@transpose_option
 @load_extension_option
 @click.pass_context
 def search(
@@ -2379,6 +2399,7 @@ def search(
     fmt,
     json_cols,
     ascii_,
+    transpose,
     load_extension,
 ):
     """Execute a full-text search against this table
@@ -2424,6 +2445,7 @@ def search(
             fmt=fmt,
             json_cols=json_cols,
             ascii_=ascii_,
+            transpose=transpose,
             param=[("query", q)],
             load_extension=load_extension,
         )
@@ -2464,6 +2486,7 @@ def search(
     help="SQL offset to use",
 )
 @output_options
+@transpose_option
 @load_extension_option
 @click.pass_context
 def rows(
@@ -2485,6 +2508,7 @@ def rows(
     fmt,
     json_cols,
     ascii_,
+    transpose,
     load_extension,
 ):
     """Output all rows in the specified table
@@ -2520,6 +2544,7 @@ def rows(
         param=param,
         json_cols=json_cols,
         ascii_=ascii_,
+        transpose=transpose,
         load_extension=load_extension,
     )
 
@@ -3796,6 +3821,20 @@ def output_rows(iterator, headers, nl, arrays, json_cols, ascii_=False):
     if first:
         # We didn't output any rows, so yield the empty list
         yield "[]"
+
+
+def output_transpose(rows, headers, no_headers):
+    # psql-style extended display: one "key = value" block per row
+    headers = [str(h) for h in headers]
+    str_rows = [["" if v is None else str(v) for v in row] for row in rows]
+    key_width = max([len(h) for h in headers], default=0)
+    val_width = max([len(v) for row in str_rows for v in row], default=0)
+    total_width = key_width + 3 + val_width
+    for i, row in enumerate(str_rows, start=1):
+        if not no_headers:
+            yield "-[ RECORD {} ]-".format(i).ljust(total_width, "-")
+        for header, value in zip(headers, row):
+            yield "{} | {}".format(header.ljust(key_width), value)
 
 
 def maybe_json(value):

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -501,6 +501,10 @@ class Database:
     :param use_old_upsert: set to ``True`` to force the older upsert implementation. See
       :ref:`python_api_old_upsert`
     :param strict: Apply STRICT mode to all created tables (unless overridden)
+    :param deserialize_json: set to ``True`` to automatically parse string column values that
+      look like JSON objects or arrays back into ``dict``/``list`` objects when rows are read
+      via ``.rows``, ``.rows_where()``, ``.get()``, ``.search()`` or ``.query()``. Defaults to
+      ``False``, so values are returned as the raw strings stored in the database.
     """
 
     _counts_table_name = "_counts"
@@ -519,10 +523,12 @@ class Database:
         execute_plugins: bool = True,
         use_old_upsert: bool = False,
         strict: bool = False,
+        deserialize_json: bool = False,
     ):
         self.memory_name = None
         self.memory = False
         self.use_old_upsert = use_old_upsert
+        self.deserialize_json = deserialize_json
         if not (
             (filename_or_conn is not None and (not memory and not memory_name))
             or (filename_or_conn is None and (memory or memory_name))
@@ -812,6 +818,13 @@ class Database:
         """.strip()
         self.execute(attach_sql)
 
+    def _row_dict(self, keys: Iterable[str], row: Sequence) -> dict:
+        "Build a row dict, deserializing JSON string values if self.deserialize_json is set."
+        d = dict(zip(keys, row))
+        if self.deserialize_json:
+            d = {key: dejsonify_if_needed(value) for key, value in d.items()}
+        return d
+
     def query(
         self, sql: str, params: Sequence | dict[str, Any] | None = None
     ) -> Generator[dict, None, None]:
@@ -857,7 +870,7 @@ class Database:
             if cursor.description is None:
                 raise ValueError(message)
             keys = dedupe_keys(d[0] for d in cursor.description)
-            return (dict(zip(keys, row)) for row in cursor)
+            return (self._row_dict(keys, row) for row in cursor)
         # Execute inside a savepoint, so a statement that turns out not to
         # return rows can be rolled back before the ValueError is raised
         self.conn.execute('SAVEPOINT "sqlite_utils_query"')
@@ -879,8 +892,8 @@ class Database:
                 fetched = cursor.fetchall()
                 self.conn.execute('RELEASE "sqlite_utils_query"')
                 released = True
-                return (dict(zip(keys, row)) for row in fetched)
-            return (dict(zip(keys, row)) for row in cursor)
+                return (self._row_dict(keys, row) for row in fetched)
+            return (self._row_dict(keys, row) for row in cursor)
         finally:
             if not released and self.conn.in_transaction:
                 # An error occurred - undo anything the statement changed.
@@ -2016,7 +2029,7 @@ class Queryable:
         cursor = self.db.execute(sql, where_args or [])
         columns = dedupe_keys(c[0] for c in cursor.description)
         for row in cursor:
-            yield dict(zip(columns, row))
+            yield self.db._row_dict(columns, row)
 
     def pks_and_rows_where(
         self,
@@ -3664,7 +3677,7 @@ class Table(Queryable):
         )
         columns = dedupe_keys(c[0] for c in cursor.description)
         for row in cursor:
-            yield dict(zip(columns, row))
+            yield self.db._row_dict(columns, row)
 
     def value_or_default(self, key: str, value: Any) -> Any:
         return self._defaults[key] if value is DEFAULT else value
@@ -5103,6 +5116,18 @@ def jsonify_if_needed(value: object) -> object:
         return str(value)
     else:
         return value
+
+
+def dejsonify_if_needed(value: object) -> object:
+    "Parse a string that looks like a JSON object or array back into a dict/list."
+    if isinstance(value, str) and value[:1] in ("{", "["):
+        try:
+            parsed = json.loads(value)
+        except ValueError:
+            return value
+        if isinstance(parsed, (dict, list)):
+            return parsed
+    return value
 
 
 def resolve_extracts(

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -505,6 +505,13 @@ class Database:
       look like JSON objects or arrays back into ``dict``/``list`` objects when rows are read
       via ``.rows``, ``.rows_where()``, ``.get()``, ``.search()`` or ``.query()``. Defaults to
       ``False``, so values are returned as the raw strings stored in the database.
+    :param json_default: optional function used as the ``default=`` callback to ``json.dumps()``
+      when serializing values (dicts, lists, tuples) to JSON on write. Use this to support types
+      that are not natively JSON-serializable, such as ``set``, ``enum.Enum`` or custom classes.
+      Defaults to ``repr``.
+    :param json_object_hook: optional function used as the ``object_hook=`` callback to
+      ``json.loads()`` when ``deserialize_json=True``. Use this to reconstruct custom types from
+      the JSON objects produced by ``json_default``.
     """
 
     _counts_table_name = "_counts"
@@ -524,11 +531,15 @@ class Database:
         use_old_upsert: bool = False,
         strict: bool = False,
         deserialize_json: bool = False,
+        json_default: Callable[[Any], Any] | None = None,
+        json_object_hook: Callable[[dict], Any] | None = None,
     ):
         self.memory_name = None
         self.memory = False
         self.use_old_upsert = use_old_upsert
         self.deserialize_json = deserialize_json
+        self.json_default = json_default
+        self.json_object_hook = json_object_hook
         if not (
             (filename_or_conn is not None and (not memory and not memory_name))
             or (filename_or_conn is None and (memory or memory_name))
@@ -822,7 +833,10 @@ class Database:
         "Build a row dict, deserializing JSON string values if self.deserialize_json is set."
         d = dict(zip(keys, row))
         if self.deserialize_json:
-            d = {key: dejsonify_if_needed(value) for key, value in d.items()}
+            d = {
+                key: dejsonify_if_needed(value, self.json_object_hook)
+                for key, value in d.items()
+            }
         return d
 
     def query(
@@ -3761,7 +3775,7 @@ class Table(Queryable):
             sets.append(
                 "{} = {}".format(quote_identifier(key), conversions.get(key, "?"))
             )
-            args.append(jsonify_if_needed(value))
+            args.append(jsonify_if_needed(value, self.db.json_default))
         wheres = [f"{quote_identifier(pk_name)} = ?" for pk_name in pks]
         args.extend(pk_values)
         sql = "update {} set {sets} where {wheres}".format(
@@ -3841,7 +3855,7 @@ class Table(Queryable):
 
             def convert_value(v):
                 bar.update(1)
-                return jsonify_if_needed(fn(v))
+                return jsonify_if_needed(fn(v), self.db.json_default)
 
             fn_name = getattr(fn, "__name__", "fn")
             if fn_name == "<lambda>":
@@ -3968,11 +3982,14 @@ class Table(Queryable):
                 # Pad short records with None, truncate long ones
                 record_len = len(record)
                 if record_len < num_columns:
-                    record_values = [jsonify_if_needed(v) for v in record] + [None] * (
-                        num_columns - record_len
-                    )
+                    record_values = [
+                        jsonify_if_needed(v, self.db.json_default) for v in record
+                    ] + [None] * (num_columns - record_len)
                 else:
-                    record_values = [jsonify_if_needed(v) for v in record[:num_columns]]
+                    record_values = [
+                        jsonify_if_needed(v, self.db.json_default)
+                        for v in record[:num_columns]
+                    ]
                 # Only process extracts if there are any
                 if has_extracts:
                     for i, key in enumerate(all_columns):
@@ -3994,7 +4011,8 @@ class Table(Queryable):
                                 if key != hash_id
                                 else hash_record(record, hash_id_columns)
                             ),
-                        )
+                        ),
+                        self.db.json_default,
                     )
                     if key in extracts and value is not None:
                         extract_table = extracts[key]
@@ -5105,11 +5123,13 @@ class View(Queryable):
                 raise
 
 
-def jsonify_if_needed(value: object) -> object:
+def jsonify_if_needed(
+    value: object, json_default: Callable[[Any], Any] | None = None
+) -> object:
     if isinstance(value, decimal.Decimal):
         return float(value)
     if isinstance(value, (dict, list, tuple)):
-        return json.dumps(value, default=repr, ensure_ascii=False)
+        return json.dumps(value, default=json_default or repr, ensure_ascii=False)
     elif isinstance(value, (datetime.time, datetime.date, datetime.datetime)):
         return value.isoformat()
     elif isinstance(value, (datetime.timedelta, uuid.UUID)):
@@ -5118,14 +5138,16 @@ def jsonify_if_needed(value: object) -> object:
         return value
 
 
-def dejsonify_if_needed(value: object) -> object:
+def dejsonify_if_needed(
+    value: object, json_object_hook: Callable[[dict], Any] | None = None
+) -> object:
     "Parse a string that looks like a JSON object or array back into a dict/list."
     if isinstance(value, str) and value[:1] in ("{", "["):
         try:
-            parsed = json.loads(value)
+            parsed = json.loads(value, object_hook=json_object_hook)
         except ValueError:
             return value
-        if isinstance(parsed, (dict, list)):
+        if isinstance(parsed, (dict, list)) or json_object_hook is not None:
             return parsed
     return value
 

--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -335,6 +335,7 @@ COLUMN_TYPE_MAPPING: dict[Any, str] = {
     "FLOAT": "FLOAT",
     "REAL": "REAL",
     "BLOB": "BLOB",
+    "JSON": "JSON",
     "text": "TEXT",
     "str": "TEXT",
     "integer": "INTEGER",
@@ -343,6 +344,7 @@ COLUMN_TYPE_MAPPING: dict[Any, str] = {
     "real": "REAL",
     "blob": "BLOB",
     "bytes": "BLOB",
+    "json": "JSON",
 }
 # If numpy is available, add more types
 if np:
@@ -532,11 +534,14 @@ class Database:
                 uri,
                 uri=True,
                 check_same_thread=False,
+                detect_types=sqlite3.PARSE_DECLTYPES,
             )
             self.memory = True
             self.memory_name = memory_name
         elif memory or filename_or_conn == ":memory:":
-            self.conn = sqlite3.connect(":memory:")
+            self.conn = sqlite3.connect(
+                ":memory:", detect_types=sqlite3.PARSE_DECLTYPES
+            )
             self.memory = True
         elif isinstance(filename_or_conn, (str, pathlib.Path)):
             if recreate and os.path.exists(filename_or_conn):
@@ -545,9 +550,13 @@ class Database:
                 except OSError:
                     # Avoid mypy and __repr__ errors, see:
                     # https://github.com/simonw/sqlite-utils/issues/503
-                    self.conn = sqlite3.connect(":memory:")
+                    self.conn = sqlite3.connect(
+                        ":memory:", detect_types=sqlite3.PARSE_DECLTYPES
+                    )
                     raise
-            self.conn = sqlite3.connect(str(filename_or_conn))
+            self.conn = sqlite3.connect(
+                str(filename_or_conn), detect_types=sqlite3.PARSE_DECLTYPES
+            )
         else:
             if recreate:
                 raise ValueError("recreate cannot be used with connections, only paths")

--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -170,6 +170,10 @@ def column_affinity(column_type: str) -> type:
     column_type = column_type.upper().strip()
     if column_type == "":
         return str  # We differ from spec, which says it should be BLOB
+    if "JSON" in column_type:
+        # Not a real SQLite affinity, but sqlite-utils treats JSON as a
+        # supported column type (see issue 579) and it is stored as text
+        return str
     if "INT" in column_type:
         return int
     if "CHAR" in column_type or "CLOB" in column_type or "TEXT" in column_type:
@@ -180,6 +184,19 @@ def column_affinity(column_type: str) -> type:
         return float
     # Default is 'NUMERIC', which we currently also treat as float
     return float
+
+
+def _json_column_converter(raw: bytes) -> Any:
+    # Registered as the sqlite3 converter for columns declared as JSON, see
+    # https://github.com/simonw/sqlite-utils/issues/579 - falls back to the
+    # decoded text unchanged if it does not turn out to be valid JSON
+    try:
+        return json.loads(raw)
+    except ValueError:
+        return raw.decode("utf-8", "replace")
+
+
+sqlite3.register_converter("JSON", _json_column_converter)
 
 
 def decode_base64_values(doc: dict[str, Any]) -> dict[str, Any]:

--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -14,6 +14,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     BinaryIO,
+    TextIO,
     TypeVar,
     Union,
     cast,
@@ -390,6 +391,58 @@ def rows_from_file(
             )
     else:
         raise RowsFromFileError("Bad format")
+
+
+def rows_to_csv(
+    rows: Iterable[Row],
+    fp: TextIO | None = None,
+    headers: Iterable[str] | None = None,
+    dialect: str | type[csv.Dialect] = "excel",
+    no_headers: bool = False,
+) -> str | None:
+    """
+    Write a sequence of dictionaries - such as rows from :meth:`.Database.query`
+    or :attr:`.Table.rows` - to CSV, mirroring the CLI's ``--csv`` output.
+
+    .. code-block:: python
+
+        from sqlite_utils.utils import rows_to_csv
+
+        csv_string = rows_to_csv([{"id": 1, "name": "Cleo"}])
+        print(csv_string)
+        # Outputs "id,name\\r\\n1,Cleo\\r\\n"
+
+    Pass ``fp=`` a writable file-like object to write there instead - in that
+    case this function returns ``None``.
+
+    :param rows: iterable of dictionaries to write
+    :param fp: optional writable file-like object - if omitted the CSV is
+      returned as a string
+    :param headers: explicit list of column headers - defaults to the keys
+      of the first row, the same as the CLI
+    :param dialect: the CSV dialect to use, defaults to ``"excel"``
+    :param no_headers: set to ``True`` to skip the header row, equivalent to
+      the CLI's ``--no-headers`` option
+    """
+    return_string = fp is None
+    out: TextIO = fp if fp is not None else io.StringIO()
+    rows_iter = iter(rows)
+    first_row = next(rows_iter, None)
+    if headers is None:
+        if first_row is None:
+            # Nothing to write and no columns were specified
+            return cast(io.StringIO, out).getvalue() if return_string else None
+        headers = list(first_row.keys())
+    writer = csv.DictWriter(
+        out, fieldnames=list(headers), dialect=dialect, extrasaction="ignore"
+    )
+    if not no_headers:
+        writer.writeheader()
+    if first_row is not None:
+        writer.writerow(first_row)
+        for row in rows_iter:
+            writer.writerow(row)
+    return cast(io.StringIO, out).getvalue() if return_string else None
 
 
 class TypeTracker:

--- a/sqlite_utils/utils.py
+++ b/sqlite_utils/utils.py
@@ -202,15 +202,32 @@ class UpdateWrapper:
     def __init__(self, wrapped: io.IOBase, update: Callable[[int], None]) -> None:
         self._wrapped = wrapped
         self._update = update
+        # If wrapped is a decoded text stream (e.g. io.TextIOWrapper set up
+        # with --encoding), len(line)/len(data) counts characters, not the
+        # bytes actually consumed from the underlying file - for a multi-byte
+        # encoding like UTF-16 that undercounts by ~2x, so progress never
+        # reaches 100% even though reading completed. Track the underlying
+        # binary buffer's position instead so progress stays honest for any
+        # encoding.
+        self._byte_source = getattr(wrapped, "buffer", None)
+        self._last_pos = self._byte_source.tell() if self._byte_source else 0
+
+    def _report(self, data_len: int) -> None:
+        if self._byte_source is not None:
+            pos = self._byte_source.tell()
+            self._update(pos - self._last_pos)
+            self._last_pos = pos
+        else:
+            self._update(data_len)
 
     def __iter__(self) -> Iterator[bytes]:
         for line in self._wrapped:
-            self._update(len(line))
+            self._report(len(line))
             yield line
 
     def read(self, size: int = -1) -> bytes:
         data = self._wrapped.read(size)
-        self._update(len(data))
+        self._report(len(data))
         return data
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2259,6 +2259,70 @@ def test_insert_encoding(tmpdir):
     ]
 
 
+def test_insert_encoding_utf16le(tmpdir):
+    # Regression test for issue #439: against utf-16-le CSV input, progress
+    # accounting used to undercount (it measured decoded characters against
+    # a byte-based file length, so it topped out around 50% - looking like a
+    # stall) even on a fully successful insert. And a genuine decode error
+    # further into the file needs to still surface as a clear exception
+    # rather than being silently swallowed.
+    db_path = str(tmpdir / "test.db")
+    csv_path = str(tmpdir / "test.csv")
+    rows = ["id,name"] + [f"{i},Name {i}" for i in range(500)]
+    with open(csv_path, "wb") as fp:
+        fp.write("\n".join(rows).encode("utf-16-le"))
+
+    result = CliRunner().invoke(
+        cli.cli,
+        [
+            "insert",
+            db_path,
+            "names",
+            csv_path,
+            "--csv",
+            "--encoding",
+            "utf-16-le",
+            "--no-detect-types",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    db = Database(db_path)
+    # All 500 data rows made it in - progress accounting didn't drop any
+    assert db["names"].count == 500
+    assert list(db["names"].rows)[:2] == [
+        {"id": "0", "name": "Name 0"},
+        {"id": "1", "name": "Name 1"},
+    ]
+
+    # A file that is genuinely invalid utf-16-le should raise a visible,
+    # descriptive error - not hang or fail silently.
+    bad_csv_path = str(tmpdir / "bad.csv")
+    good_bytes = "\n".join(rows).encode("utf-16-le")
+    # Splice in an unpaired surrogate code unit part-way through the file,
+    # aligned to a 2-byte utf-16 code unit boundary
+    midpoint = (len(good_bytes) // 2) & ~1
+    bad_bytes = good_bytes[:midpoint] + b"\x00\xd8" + good_bytes[midpoint:]
+    with open(bad_csv_path, "wb") as fp:
+        fp.write(bad_bytes)
+
+    bad_result = CliRunner().invoke(
+        cli.cli,
+        [
+            "insert",
+            str(tmpdir / "bad.db"),
+            "names",
+            bad_csv_path,
+            "--csv",
+            "--encoding",
+            "utf-16-le",
+        ],
+        catch_exceptions=False,
+    )
+    assert bad_result.exit_code == 1
+    assert "codec can't decode" in bad_result.output
+
+
 @pytest.mark.parametrize("fts", ["FTS4", "FTS5"])
 @pytest.mark.parametrize(
     "extra_arg,expected",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1137,6 +1137,40 @@ def test_query_json_with_json_cols(db_path):
     assert expected == result_rows.output.strip()
 
 
+def test_query_json_declared_column_type_auto_decoded(db_path):
+    # Columns declared as JSON should be decoded automatically, without
+    # needing --json-cols - see https://github.com/simonw/sqlite-utils/issues/579
+    db = Database(db_path)
+    with db.conn:
+        db.execute(
+            "CREATE TABLE dogs (id INTEGER PRIMARY KEY, name TEXT, friends JSON)"
+        )
+        db["dogs"].insert(
+            {
+                "id": 1,
+                "name": "Cleo",
+                "friends": json.dumps([{"name": "Pancakes"}, {"name": "Bailey"}]),
+            }
+        )
+    expected = r"""
+    [{"id": 1, "name": "Cleo", "friends": [{"name": "Pancakes"}, {"name": "Bailey"}]}]
+    """.strip()
+    result = CliRunner().invoke(
+        cli.cli, [db_path, "select id, name, friends from dogs"]
+    )
+    assert expected == result.output.strip()
+    result_rows = CliRunner().invoke(cli.cli, ["rows", db_path, "dogs"])
+    assert expected == result_rows.output.strip()
+    # Flat formats should keep it as a JSON string, not a Python repr
+    result_csv = CliRunner().invoke(
+        cli.cli, [db_path, "select id, name, friends from dogs", "--csv"]
+    )
+    assert (
+        '1,Cleo,"[{""name"": ""Pancakes""}, {""name"": ""Bailey""}]"'
+        in result_csv.output
+    )
+
+
 def test_query_json_unicode_not_escaped_by_default(db_path):
     db = Database(db_path)
     with db.conn:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -760,6 +760,58 @@ def test_query_csv(db_path, format, expected):
     assert result.output.strip().replace("\r", "") == expected_rest
 
 
+def test_query_transpose(db_path):
+    db = Database(db_path)
+    with db.conn:
+        db["dogs"].insert_all(
+            [
+                {"id": 1, "age": 4, "name": "Cleo"},
+                {"id": 2, "age": 2, "name": "Pancakes"},
+            ]
+        )
+    result = CliRunner().invoke(
+        cli.cli,
+        [db_path, "select id, name, age from dogs", "--transpose"],
+    )
+    assert result.exit_code == 0
+    assert result.output == (
+        "-[ RECORD 1 ]--\n"
+        "id   | 1\n"
+        "name | Cleo\n"
+        "age  | 4\n"
+        "-[ RECORD 2 ]--\n"
+        "id   | 2\n"
+        "name | Pancakes\n"
+        "age  | 2\n"
+    )
+    # -x is a shorthand for --transpose
+    result2 = CliRunner().invoke(
+        cli.cli, [db_path, "select id, name, age from dogs", "-x"]
+    )
+    assert result2.output == result.output
+    # --no-headers drops the "-[ RECORD n ]-" separators
+    result3 = CliRunner().invoke(
+        cli.cli,
+        [db_path, "select id, name, age from dogs", "--transpose", "--no-headers"],
+    )
+    assert result3.exit_code == 0
+    assert (
+        result3.output
+        == "id   | 1\nname | Cleo\nage  | 4\nid   | 2\nname | Pancakes\nage  | 2\n"
+    )
+
+
+def test_rows_transpose(db_path):
+    db = Database(db_path)
+    with db.conn:
+        db["dogs"].insert_all(
+            [{"id": 1, "name": "Cleo", "age": 4}], column_order=("id", "name", "age")
+        )
+    result = CliRunner().invoke(cli.cli, ["rows", db_path, "dogs", "-x"])
+    assert result.exit_code == 0
+    assert result.output == "-[ RECORD 1 ]-\nid   | 1\nname | Cleo\nage  | 4\n"
+
+
 _all_query = "select id, name, age from dogs"
 _one_query = "select id, name, age from dogs where id = 1"
 

--- a/tests/test_cli_insert.py
+++ b/tests/test_cli_insert.py
@@ -79,6 +79,55 @@ def test_insert_json_flatten_nl(tmpdir):
     ]
 
 
+def test_insert_json_key(tmpdir):
+    db_path = str(tmpdir / "dogs.db")
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "dogs", "-", "--key", "List"],
+        input=json.dumps(
+            {"List": [{"id": 1, "name": "Cleo"}, {"id": 2, "name": "Suna"}]}
+        ),
+    )
+    assert result.exit_code == 0
+    assert list(Database(db_path).query("select * from dogs")) == [
+        {"id": 1, "name": "Cleo"},
+        {"id": 2, "name": "Suna"},
+    ]
+
+
+def test_insert_json_key_missing_errors(tmpdir):
+    db_path = str(tmpdir / "dogs.db")
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "dogs", "-", "--key", "Missing"],
+        input=json.dumps({"List": [{"id": 1}]}),
+    )
+    assert result.exit_code == 1
+    assert "JSON key 'Missing' not found in input" in result.output
+
+
+def test_insert_json_key_not_a_list_errors(tmpdir):
+    db_path = str(tmpdir / "dogs.db")
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "dogs", "-", "--key", "List"],
+        input=json.dumps({"List": {"id": 1}}),
+    )
+    assert result.exit_code == 1
+    assert "JSON key 'List' is not a list" in result.output
+
+
+def test_insert_json_key_rejects_nl(tmpdir):
+    db_path = str(tmpdir / "dogs.db")
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "dogs", "-", "--key", "List", "--nl"],
+        input=json.dumps({"id": 1}),
+    )
+    assert result.exit_code == 1
+    assert "--key cannot be used with" in result.output
+
+
 @pytest.mark.parametrize(
     "args,expected_pks",
     (

--- a/tests/test_cli_insert.py
+++ b/tests/test_cli_insert.py
@@ -212,6 +212,57 @@ def test_insert_not_null_default(db_path, tmpdir):
     ) == db["dogs"].schema
 
 
+def test_insert_extract(db_path, tmpdir):
+    json_path = str(tmpdir / "trees.json")
+    trees = [
+        {"id": 1, "name": "Lila", "species": "Oak"},
+        {"id": 2, "name": "Suna", "species": "Oak"},
+        {"id": 3, "name": "Pancake", "species": "Palm"},
+    ]
+    with open(json_path, "w") as fp:
+        fp.write(json.dumps(trees))
+    result = CliRunner().invoke(
+        cli.cli,
+        ["insert", db_path, "trees", json_path, "--pk", "id", "--extract", "species"],
+    )
+    assert result.exit_code == 0, result.output
+    db = Database(db_path)
+    assert {"trees", "species"} <= set(db.table_names())
+    assert list(db["species"].rows) == [
+        {"id": 1, "value": "Oak"},
+        {"id": 2, "value": "Palm"},
+    ]
+    assert list(db["trees"].rows) == [
+        {"id": 1, "name": "Lila", "species": 1},
+        {"id": 2, "name": "Suna", "species": 1},
+        {"id": 3, "name": "Pancake", "species": 2},
+    ]
+
+
+def test_insert_extract_custom_table_name(db_path, tmpdir):
+    json_path = str(tmpdir / "trees.json")
+    trees = [{"id": 1, "species": "Oak"}]
+    with open(json_path, "w") as fp:
+        fp.write(json.dumps(trees))
+    result = CliRunner().invoke(
+        cli.cli,
+        [
+            "insert",
+            db_path,
+            "trees",
+            json_path,
+            "--pk",
+            "id",
+            "--extract",
+            "species:Species",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    db = Database(db_path)
+    assert {"trees", "Species"} <= set(db.table_names())
+    assert list(db["Species"].rows) == [{"id": 1, "value": "Oak"}]
+
+
 def test_insert_binary_base64(db_path):
     result = CliRunner().invoke(
         cli.cli,

--- a/tests/test_column_affinity.py
+++ b/tests/test_column_affinity.py
@@ -32,6 +32,9 @@ EXAMPLES = [
     ("BOOLEAN", float),
     ("DATE", float),
     ("DATETIME", float),
+    # Not a real SQLite affinity, but sqlite-utils treats it as TEXT so
+    # transform() does not mangle JSON columns - see issue 579
+    ("JSON", str),
 ]
 
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -899,6 +899,28 @@ def test_insert_dictionaries_and_lists_as_json(fresh_db, data_structure):
     assert data_structure == json.loads(row[1])
 
 
+def test_deserialize_json(fresh_db):
+    fresh_db["test"].insert(
+        {"id": 1, "data": {"foo": "bar"}, "tags": [1, 2, 3], "name": "not json"},
+        pk="id",
+    )
+    # Default behaviour: values come back as the raw JSON strings that were stored
+    row = fresh_db["test"].get(1)
+    assert row["data"] == '{"foo": "bar"}'
+    assert row["tags"] == "[1, 2, 3]"
+    assert row["name"] == "not json"
+
+    # Opt-in: deserialize_json=True parses them back into dict/list
+    db2 = Database(fresh_db.conn, deserialize_json=True)
+    row2 = db2["test"].get(1)
+    assert row2["data"] == {"foo": "bar"}
+    assert row2["tags"] == [1, 2, 3]
+    assert row2["name"] == "not json"
+    # Also applies to .rows, .rows_where() and .query()
+    assert list(db2["test"].rows)[0]["data"] == {"foo": "bar"}
+    assert list(db2.query("select data from test"))[0]["data"] == {"foo": "bar"}
+
+
 def test_insert_list_nested_unicode(fresh_db):
     fresh_db["test"].insert(
         {"id": 1, "data": {"key1": {"nested": ["cømplex"]}}}, pk="id"

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -921,6 +921,46 @@ def test_deserialize_json(fresh_db):
     assert list(db2.query("select data from test"))[0]["data"] == {"foo": "bar"}
 
 
+def test_json_default_and_object_hook(fresh_db):
+    import enum
+
+    class Color(enum.Enum):
+        RED = "red"
+
+    def encode(value):
+        if isinstance(value, set):
+            return sorted(value)
+        if isinstance(value, enum.Enum):
+            return {"__enum__": value.value}
+        raise TypeError(value)
+
+    def decode(obj):
+        if "__enum__" in obj:
+            return Color(obj["__enum__"])
+        return obj
+
+    # A set/enum can't be a column's own type (SQLite has no such type), but they
+    # are common inside a dict/list column value - that's what json_default is for.
+    db = Database(fresh_db.conn, json_default=encode)
+    db["test"].insert(
+        {"id": 1, "data": {"tags": {"b", "a"}, "color": Color.RED}},
+        pk="id",
+    )
+    row = db.execute("select data from test").fetchone()
+    assert row[0] == '{"tags": ["a", "b"], "color": {"__enum__": "red"}}'
+
+    # Without json_default, an unsupported nested type falls back to repr()
+    db_default = Database(fresh_db.conn)
+    db_default["test2"].insert({"id": 1, "data": {"tags": {"a"}}}, pk="id")
+    row2 = db_default.execute("select data from test2").fetchone()
+    assert row2[0] == json.dumps({"tags": repr({"a"})})
+
+    # json_object_hook reconstructs the custom type on read
+    db2 = Database(fresh_db.conn, deserialize_json=True, json_object_hook=decode)
+    row3 = db2["test"].get(1)
+    assert row3["data"] == {"tags": ["a", "b"], "color": Color.RED}
+
+
 def test_insert_list_nested_unicode(fresh_db):
     fresh_db["test"].insert(
         {"id": 1, "data": {"key1": {"nested": ["cømplex"]}}}, pk="id"

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -376,6 +376,12 @@ def test_create_error_if_invalid_self_referential_foreign_keys(fresh_db):
         ),
         ("blob", "blob", None, 'CREATE TABLE "dogs" (\n   "name" TEXT\n, "blob" BLOB)'),
         (
+            "friends",
+            "JSON",
+            None,
+            'CREATE TABLE "dogs" (\n   "name" TEXT\n, "friends" JSON)',
+        ),
+        (
             "default_str",
             None,
             None,

--- a/tests/test_insert_files.py
+++ b/tests/test_insert_files.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import sys
+import zlib
 
 import pytest
 from click.testing import CliRunner
@@ -169,6 +170,55 @@ def test_insert_files_fixed_value_column_bad_type():
         )
         assert result.exit_code == 1
         assert "colname:text:value" in result.output
+
+
+def test_insert_files_sqlar():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        tmpdir = pathlib.Path(".")
+        db_path = str(tmpdir / "files.db")
+        # Compresses well - lots of repetition
+        compressible = b"abcdefgh" * 1000
+        # Does not compress smaller than the original
+        incompressible = os.urandom(20)
+        (tmpdir / "one.txt").write_bytes(compressible)
+        (tmpdir / "two.bin").write_bytes(incompressible)
+        result = runner.invoke(
+            cli.cli,
+            ["insert-files", db_path, "sqlar", str(tmpdir), "--sqlar"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        db = Database(db_path)
+        assert db["sqlar"].columns_dict == {
+            "name": str,
+            "mode": int,
+            "mtime": int,
+            "sz": int,
+            "data": bytes,
+        }
+        assert db["sqlar"].pks == ["name"]
+        rows_by_name = {r["name"]: r for r in db["sqlar"].rows}
+        one, two = rows_by_name["one.txt"], rows_by_name["two.bin"]
+        assert one["sz"] == len(compressible)
+        assert len(one["data"]) < len(compressible)
+        assert zlib.decompress(one["data"]) == compressible
+        assert two["sz"] == len(incompressible)
+        assert two["data"] == incompressible
+
+
+def test_insert_files_sqlar_and_text_conflict():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        tmpdir = pathlib.Path(".")
+        db_path = str(tmpdir / "files.db")
+        (tmpdir / "one.txt").write_text("hello", "utf-8")
+        result = runner.invoke(
+            cli.cli,
+            ["insert-files", db_path, "files", str(tmpdir), "--text", "--sqlar"],
+        )
+        assert result.exit_code == 1
+        assert "Cannot use --text and --sqlar together" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_insert_files.py
+++ b/tests/test_insert_files.py
@@ -117,6 +117,60 @@ def test_insert_files(silent, pk_args, expected_pks):
         assert set(db["files"].pks) == set(expected_pks)
 
 
+def test_insert_files_fixed_value_column():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        tmpdir = pathlib.Path(".")
+        db_path = str(tmpdir / "files.db")
+        (tmpdir / "one.gif").write_text("gif content", "utf-8")
+        result = runner.invoke(
+            cli.cli,
+            [
+                "insert-files",
+                db_path,
+                "files",
+                str(tmpdir / "one.gif"),
+                "-c",
+                "path",
+                "-c",
+                "content",
+                "-c",
+                "file_type:text:gif",
+                "--pk",
+                "path",
+                "--pk",
+                "file_type",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        db = Database(db_path)
+        row = next(iter(db["files"].rows))
+        assert row["file_type"] == "gif"
+        assert set(db["files"].pks) == {"path", "file_type"}
+
+
+def test_insert_files_fixed_value_column_bad_type():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        tmpdir = pathlib.Path(".")
+        db_path = str(tmpdir / "files.db")
+        (tmpdir / "one.gif").write_text("gif content", "utf-8")
+        result = runner.invoke(
+            cli.cli,
+            [
+                "insert-files",
+                db_path,
+                "files",
+                str(tmpdir / "one.gif"),
+                "-c",
+                "file_type:mtime:gif",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "colname:text:value" in result.output
+
+
 @pytest.mark.parametrize(
     "use_text,encoding,input,expected",
     (

--- a/tests/test_insert_files.py
+++ b/tests/test_insert_files.py
@@ -207,6 +207,60 @@ def test_insert_files_sqlar():
         assert two["data"] == incompressible
 
 
+def test_insert_files_convert():
+    # Same effect as --sqlar, but implemented using --convert against
+    # plain content/size columns - no separate `convert` command needed.
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        tmpdir = pathlib.Path(".")
+        db_path = str(tmpdir / "files.db")
+        compressible = b"abcdefgh" * 1000
+        (tmpdir / "one.txt").write_bytes(compressible)
+        result = runner.invoke(
+            cli.cli,
+            [
+                "insert-files",
+                db_path,
+                "files",
+                str(tmpdir / "one.txt"),
+                "-c",
+                "name:name",
+                "-c",
+                "data:content",
+                "--convert",
+                'row["data"] = zlib.compress(row["data"])',
+                "--import",
+                "zlib",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        db = Database(db_path)
+        row = list(db["files"].rows)[0]
+        assert zlib.decompress(row["data"]) == compressible
+
+
+def test_insert_files_convert_syntax_error():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        tmpdir = pathlib.Path(".")
+        db_path = str(tmpdir / "files.db")
+        (tmpdir / "one.txt").write_text("hello", "utf-8")
+        result = runner.invoke(
+            cli.cli,
+            [
+                "insert-files",
+                db_path,
+                "files",
+                str(tmpdir),
+                "--convert",
+                "def broken(:",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Could not compile code" in result.output
+
+
 def test_insert_files_sqlar_and_text_conflict():
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import os
 
 import pytest
 
@@ -124,3 +125,27 @@ def test_rows_to_csv_no_headers():
 def test_rows_to_csv_empty_rows():
     assert utils.rows_to_csv([]) == ""
     assert utils.rows_to_csv([], headers=["id", "name"]) == "id,name\r\n"
+
+
+def test_update_wrapper_reports_honest_bytes_for_utf16(tmpdir):
+    # Regression test for issue #439: UpdateWrapper used to count decoded
+    # *characters* (len(line)) against a progress length measured in bytes.
+    # For utf-16-le every ASCII character is encoded as 2 bytes, so the
+    # reported progress topped out at ~50% of the file even though reading
+    # had actually finished - looking like a stall. It should now track the
+    # underlying binary stream's position, so total reported progress
+    # matches the file size exactly regardless of encoding.
+    path = str(tmpdir / "utf16.csv")
+    text = "id,name\n" + "".join(f"{i},Alice{i}\n" for i in range(500))
+    with open(path, "wb") as fp:
+        fp.write(text.encode("utf-16-le"))
+    file_length = os.path.getsize(path)
+
+    reported = []
+    with open(path, "rb") as fp:
+        decoded = io.TextIOWrapper(fp, encoding="utf-16-le")
+        wrapper = utils.UpdateWrapper(decoded, reported.append)
+        for _line in wrapper:
+            pass
+
+    assert sum(reported) == file_length

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,3 +102,25 @@ def test_flatten(input, expected):
 )
 def test_dedupe_keys(input, expected):
     assert utils.dedupe_keys(input) == expected
+
+
+def test_rows_to_csv_returns_string():
+    rows = [{"id": 1, "name": "Cleo"}, {"id": 2, "name": "Pancakes"}]
+    assert utils.rows_to_csv(rows) == "id,name\r\n1,Cleo\r\n2,Pancakes\r\n"
+
+
+def test_rows_to_csv_writes_to_fp():
+    fp = io.StringIO()
+    result = utils.rows_to_csv([{"id": 1, "name": "Cleo"}], fp=fp)
+    assert result is None
+    assert fp.getvalue() == "id,name\r\n1,Cleo\r\n"
+
+
+def test_rows_to_csv_no_headers():
+    csv_string = utils.rows_to_csv([{"id": 1, "name": "Cleo"}], no_headers=True)
+    assert csv_string == "1,Cleo\r\n"
+
+
+def test_rows_to_csv_empty_rows():
+    assert utils.rows_to_csv([]) == ""
+    assert utils.rows_to_csv([], headers=["id", "name"]) == "id,name\r\n"


### PR DESCRIPTION
- **insert-files: support fixed value columns via -c colname:text:value**
- **Add rows_to_csv() Python API helper for writing rows as CSV (issue #580)**
- **Add --key option to insert/upsert/bulk for importing JSON lists nested under a top-level key**
- **insert-files: add --sqlar flag and content_sqlar column for sqlar-compatible compressed payloads**
- **insert-files: add --convert/--import to transform rows during import**
- **Add --transpose/-x option to rows, query, memory and search for wide records**
- **Fix dishonest progress accounting for multi-byte encoded CSV input (#439)**
- **Auto-decode columns declared as JSON in output modes (issue #579)**
- **Add --extract option to insert/upsert commands**
- **Add opt-in Database(deserialize_json=True) to parse JSON strings back into dict/list on read**
- **Add Database(json_default=, json_object_hook=) for custom JSON encoding/decoding**


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--826.org.readthedocs.build/en/826/

<!-- readthedocs-preview sqlite-utils end -->