### PR TITLE
Escape tokenize argument in enable_fts to prevent SQL injection

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -3378,7 +3378,9 @@ class Table(Queryable):
                 table_fts=quote_identifier(self.name + "_fts"),
                 columns=", ".join(quote_identifier(c) for c in columns),
                 fts_version=fts_version,
-                tokenize=f"\n    tokenize='{tokenize}'," if tokenize else "",
+                tokenize=(
+                    f"\n    tokenize={self.db.quote(tokenize)}," if tokenize else ""
+                ),
             )
         )
         should_recreate = False

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -252,6 +252,18 @@ def test_fts_tokenize(fresh_db, fts_version):
     }.items() <= rows[0].items()
 
 
+def test_fts_tokenize_escaped(fresh_db):
+    # A malicious tokenize value must not be able to break out of the
+    # string literal in the CREATE VIRTUAL TABLE statement.
+    table = fresh_db["searchable"]
+    table.insert_all(search_records)
+    malicious = "porter'); CREATE TABLE injected(x); --"
+    with pytest.raises(Exception):
+        table.enable_fts(["text"], tokenize=malicious)
+    # The injected statement must not have executed
+    assert "injected" not in fresh_db.table_names()
+
+
 def test_optimize_fts(fresh_db):
     for fts_version in ("4", "5"):
         table_name = f"searchable_{fts_version}"


### PR DESCRIPTION
## Summary

`Table.enable_fts(tokenize=...)` interpolated the `tokenize` value directly into the `CREATE VIRTUAL TABLE` statement inside a single-quoted string literal:

```python
tokenize=f"\n    tokenize='{tokenize}'," if tokenize else "",
```

Because the statement runs through `executescript()`, a `tokenize` value containing a single quote can close the literal and append additional statements. This is reachable from the CLI via `sqlite-utils enable-fts ... --tokenize`.

## Fix

Route the value through the existing `Database.quote()` helper, which uses SQLite's own `quote()` to escape the string. Legitimate tokenizers such as `porter` (and multi-word forms like `porter unicode61`) are unaffected, for both FTS4 and FTS5.

## Test

Added `test_fts_tokenize_escaped`, which confirms a crafted `tokenize` value cannot create an extra table. Existing tokenize tests (`test_fts_tokenize`) still pass.

```
python -m pytest tests/test_fts.py -q
# 52 passed
```

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--828.org.readthedocs.build/en/828/

<!-- readthedocs-preview sqlite-utils end -->