### PR TITLE
Fix count_where() raising OperationalError on nonexistent tables

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2023,6 +2023,8 @@ class Queryable:
         :param where_args: Parameters to use with that fragment - an iterable for ``id > ?``
           parameters, or a dictionary for ``id > :id``
         """
+        if not self.exists():
+            return 0
         sql = f"select count(*) from {quote_identifier(self.name)}"
         if where is not None:
             sql += " where " + where

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -96,6 +96,12 @@ def test_count_where(existing_db):
     assert existing_db.table("foo").count_where("text != :t", {"t": "two"}) == 2
 
 
+def test_count_where_nonexistent_table(fresh_db):
+    assert fresh_db.table("does_not_exist").count_where() == 0
+    assert fresh_db.table("does_not_exist").count_where("id > ?", [5]) == 0
+    assert fresh_db.table("does_not_exist").count == 0
+
+
 def test_columns(existing_db):
     table = existing_db.table("foo")
     assert [{"name": "text", "type": "TEXT"}] == [


### PR DESCRIPTION
rows_where() and delete_where() both return gracefully when called on a table that does not yet exist, but count_where() propagates an OperationalError from SQLite instead of returning 0. This adds an existence check at the top of count_where() to make its behaviour consistent with the rest of the API. Adds a test covering count_where() and the count property on a nonexistent table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjQWzvQTBBmJeg6czcNbsT)_

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--840.org.readthedocs.build/en/840/

<!-- readthedocs-preview sqlite-utils end -->