### PR TITLE
docs: render insert --convert and query --functions with literal hyphens

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -3035,7 +3035,7 @@ See this `SpatiaLite Cookbook recipe <http://www.gaia-gis.it/gaia-sins/spatialit
 Installing packages
 ===================
 
-The :ref:`convert command <cli_convert>` and the :ref:`insert -\\-convert <cli_insert_convert>` and :ref:`query -\\-functions <cli_query_functions>` options can be provided with a Python script that imports additional modules from the ``sqlite-utils`` environment.
+The :ref:`convert command <cli_convert>` and the :ref:`insert <cli_insert_convert>` ``--convert`` and :ref:`query <cli_query_functions>` ``--functions`` options can be provided with a Python script that imports additional modules from the ``sqlite-utils`` environment.
 
 You can install packages from PyPI directly into the correct environment using ``sqlite-utils install <package>``. This is a wrapper around ``pip install``.
 


### PR DESCRIPTION
## Summary
Sphinx smartquotes turns `--` into an en-dash when those flags sit in `:ref:` display text, so the install docs showed `insert –convert` and `query –functions`.

Moved the flags into RST code roles (` ``--convert`` ` / ` ``--functions`` `) and left the `:ref:` links on `insert` and `query`. Smartquotes does not rewrite literals, so the CLI flags stay copyable.

Fixes #493

## Test plan
- [ ] Confirm the install section at `cli.html#cli-install` shows `insert --convert` and `query --functions` (two hyphens, not an en-dash)
- [ ] Confirm the `insert` and `query` words still link to `cli_insert_convert` and `cli_query_functions`

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--844.org.readthedocs.build/en/844/

<!-- readthedocs-preview sqlite-utils end -->