### PR TITLE
docs: keep CLI options literal in Python API cross-links

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -185,7 +185,7 @@ You can attach an additional database using the ``.attach()`` method, providing 
 You can reference tables in the attached database using the alias value you passed to ``db.attach(alias, filepath)`` as a prefix, for example the ``second.table_in_second`` reference in the SQL query above.
 
 .. note::
-    In the CLI: :ref:`sqlite-utils --attach <cli_query_attach>`
+    In the CLI: :ref:`sqlite-utils <cli_query_attach>` ``--attach``
 
 .. _python_api_tracing:
 
@@ -1025,7 +1025,7 @@ Here's an example that uses these features:
 
 
 .. note::
-    In the CLI: :ref:`sqlite-utils insert --not-null and --default <cli_defaults_not_null>`
+    In the CLI: :ref:`sqlite-utils insert <cli_defaults_not_null>` ``--not-null`` and ``--default``
 
 .. _python_api_rename_table:
 
@@ -1188,7 +1188,7 @@ To replace any existing records that have a matching primary key, use the ``repl
     Prior to sqlite-utils 2.0 the ``.upsert()`` and ``.upsert_all()`` methods worked the same way as ``.insert(replace=True)`` does today. See :ref:`python_api_upsert` for the new behaviour of those methods introduced in 2.0.
 
 .. note::
-    In the CLI: :ref:`sqlite-utils insert --replace <cli_insert_replace>`
+    In the CLI: :ref:`sqlite-utils insert <cli_insert_replace>` ``--replace``
 
 .. _python_api_update:
 
@@ -1657,7 +1657,7 @@ You can insert or update data that includes new columns and have the table autom
     new_table.insert({"name": "Gareth", "age": 32, "shoe_size": 11})
 
 .. note::
-    In the CLI: :ref:`sqlite-utils insert --alter <cli_add_column_alter>`
+    In the CLI: :ref:`sqlite-utils insert <cli_add_column_alter>` ``--alter``
 
 .. _python_api_add_foreign_key:
 
@@ -3360,7 +3360,7 @@ You can cause ``sqlite3`` to return more useful errors, including the traceback 
     sqlite3.enable_callback_tracebacks(True)
 
 .. note::
-    In the CLI: :ref:`sqlite-utils query --functions <cli_query_functions>`
+    In the CLI: :ref:`sqlite-utils query <cli_query_functions>` ``--functions``
 
 .. _python_api_quote:
 
@@ -3495,7 +3495,7 @@ Initialize SpatiaLite
    :noindex:
 
 .. note::
-    In the CLI: :ref:`sqlite-utils create-database --init-spatialite <cli_create_database>`
+    In the CLI: :ref:`sqlite-utils create-database <cli_create_database>` ``--init-spatialite``
 
 .. _python_api_gis_find_spatialite:
 


### PR DESCRIPTION
## Summary

Sphinx's smartquotes transform rewrites `--` as an en dash when an option appears inside `:ref:` link text. Issue #493 tracks this rendering problem, and #844 addresses the two affected links in the install section. Six CLI cross-links in `docs/python-api.rst` still had the same issue.

This PR updates only those six notes by keeping the command name as an internal reference and rendering each option as an inline literal. The generated documentation now preserves copyable `--attach`, `--not-null`, `--default`, `--replace`, `--alter`, `--functions`, and `--init-spatialite` flags.

## Verification

- `uv run --group docs sphinx-build -W -b html docs /tmp/sqlite-utils-docs-build`
- `uv run cog --check README.md docs/*.rst`
- `uv run --group docs codespell docs/python-api.rst --ignore-words docs/codespell-ignore-words.txt`
- `git diff --check`
- Rendered HTML inspection confirmed the six links and literal flags.

A full Sphinx linkcheck also ran. It reported two pre-existing unrelated broken links in `docs/contributing.rst` and the existing WGS84 link in `docs/python-api.rst`; neither file location was changed by this PR.

Documentation only; no runtime behavior changes and no changelog entry is needed.

Related to #493. Follow-up to #844.

OpenAI Codex assisted with implementation and verification. Human review remains required.

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--848.org.readthedocs.build/en/848/

<!-- readthedocs-preview sqlite-utils end -->