### PR TITLE
fix: raise NoTable from rows_where() and delete_where() for non-existent tables

### DIFF
--- a/sqlite_utils/db.py
+++ b/sqlite_utils/db.py
@@ -2160,7 +2160,7 @@ class Queryable:
         :param offset: Integer for SQL offset
         """
         if not self.exists():
-            return
+            raise NoTable(f"Table {self.name} does not exist")
         sql = f"select {select} from {quote_identifier(self.name)}"
         if where is not None:
             sql += " where " + where
@@ -4105,7 +4105,7 @@ class Table(Queryable):
         :param analyze: Set to ``True`` to run ``ANALYZE`` after the rows have been deleted.
         """
         if not self.exists():
-            return self
+            raise NoTable(f"Table {self.name} does not exist")
         sql = f"delete from {quote_identifier(self.name)}"
         if where is not None:
             sql += " where " + where

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,4 +1,6 @@
+import pytest
 import sqlite_utils
+from sqlite_utils.db import NoTable
 
 
 def test_delete_rowid_table(fresh_db):
@@ -62,3 +64,8 @@ def test_delete_where_analyze(fresh_db):
     assert list(fresh_db.table("sqlite_stat1").rows) == [
         {"tbl": "table", "idx": "idx_table_i", "stat": "6 1"}
     ]
+
+
+def test_delete_where_nonexistent_table(fresh_db):
+    with pytest.raises(NoTable):
+        fresh_db.table("does_not_exist").delete_where()

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -147,3 +147,9 @@ def test_pks_and_rows_where_compound_pk_declaration_order(fresh_db):
     fresh_db.table("t").insert({"a": "A", "b": "B"})
     pks_and_rows = list(fresh_db.table("t").pks_and_rows_where())
     assert pks_and_rows == [(("A", "B"), {"b": "B", "a": "A"})]
+
+
+def test_rows_where_nonexistent_table_raises(fresh_db):
+    from sqlite_utils.db import NoTable
+    with pytest.raises(NoTable):
+        list(fresh_db.table("does_not_exist").rows_where())


### PR DESCRIPTION
rows_where() silently returned an empty iterator and delete_where() silently returned self when called on a table that does not exist, masking bugs in callers that passed a wrong table name. Both methods now raise NoTable, matching the behaviour of count_where() and duplicate(), as described in issue #841 as the intended v5 behaviour. Fixes #841

<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--850.org.readthedocs.build/en/850/

<!-- readthedocs-preview sqlite-utils end -->