### PR TITLE
docs: clarify transform() behavior for indexes, views and triggers

### DIFF
--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -2031,7 +2031,7 @@ To achieve this, the SQL produced by ``transform_sql()`` turns on ``PRAGMA legac
 Custom transformations with .transform_sql()
 --------------------------------------------
 
-The ``.transform()`` method can handle most cases, but it does not automatically upgrade indexes, views or triggers associated with the table that is being transformed.
+The ``.transform()`` method preserves and recreates indexes where possible, and tables referenced by views can be safely transformed (see :ref:`python_api_transform_views`). However, view definitions and triggers are not automatically rewritten when their referenced columns change, so those definitions may need to be updated manually.
 
 If you want to do something more advanced, you can call the ``table.transform_sql(...)`` method with the same arguments that you would have passed to ``table.transform(...)``.
 


### PR DESCRIPTION
Closes #849

### Summary of Change

Updates the overview paragraph in the `Custom transformations with .transform_sql()` section of the Python API documentation to accurately reflect the current behavior of `.transform()`:

- **Indexes**: Preserves and recreates indexes where possible (rather than stating they are not upgraded).
- **Views**: Cross-references the `Tables referenced by views` section explaining that referenced tables are safely transformed without breaking view definitions.
- **Triggers & Column Changes**: Clarifies that view definitions and triggers referencing renamed or dropped columns must still be manually updated.

### Verification

- Ran `cog -r docs/*.rst`
- Ran `flake8` and `mypy sqlite_utils` (clean pass)
- Ran `pytest tests/test_docs.py tests/test_transform.py` (212 passed)


<!-- readthedocs-preview sqlite-utils start -->
----
📚 Documentation preview 📚: https://sqlite-utils--851.org.readthedocs.build/en/851/

<!-- readthedocs-preview sqlite-utils end -->